### PR TITLE
Webtoon Not Persistent 32-bit Color Mode Fix

### DIFF
--- a/app/src/main/kotlin/org/draken/usagi/reader/ui/pager/BasePageHolder.kt
+++ b/app/src/main/kotlin/org/draken/usagi/reader/ui/pager/BasePageHolder.kt
@@ -95,6 +95,7 @@ abstract class BasePageHolder<B : ViewBinding>(
 
 	fun reloadImage() {
 		val source = (viewModel.state.value as? PageState.Shown)?.source ?: return
+		settings.applyBitmapConfig(ssiv) // Enforce config before image reload
 		ssiv.setImage(source)
 	}
 
@@ -183,11 +184,13 @@ abstract class BasePageHolder<B : ViewBinding>(
 
 			is PageState.Loaded -> {
 				bindingInfo.textViewStatus.setText(R.string.preparing_)
+				settings.applyBitmapConfig(ssiv) // Enforce config before image mount
 				ssiv.setImage(state.source)
 			}
 
 			is PageState.Loading -> {
 				if (state.preview != null && ssiv.getState() == null) {
+					settings.applyBitmapConfig(ssiv) // Enforce config before preview mount
 					ssiv.setImage(state.preview)
 				}
 			}

--- a/app/src/main/kotlin/org/draken/usagi/reader/ui/pager/webtoon/WebtoonHolder.kt
+++ b/app/src/main/kotlin/org/draken/usagi/reader/ui/pager/webtoon/WebtoonHolder.kt
@@ -30,7 +30,9 @@ class WebtoonHolder(
 	private var scrollToRestore = 0
 
 	init {
-		bindingInfo.progressBar.setVisibilityAfterHide(View.GONE)
+		binding.root.post {
+			bindingInfo.progressBar.setVisibilityAfterHide(View.GONE)
+		}
 	}
 
 	override fun onReady() {


### PR DESCRIPTION
ok this is gonna be long. sorry about it.

# First is the description of the problem (written by me and not AI) :

the problem is in webtoon mode. if you are reading a manhwa that is in high quality. there's going to be a lot of banding. i first noticed this when I used mihon along side usagi.

mihon didn't have this banding weird artifacts look in the image. while usagi had it. I then tried toggling off and on the 32 bit mode option in usagi reader (by going to reader settings while I am reading the chapter. from the action bar or whatever the name of that reader bar down there).

and the banding was gone. that was weird. but once i close the reader and come back. the banding is back and I have to redo this to fix it.

so basically the 32 bit mode isn't persistent for some reason. that was my personal conclusion.

then I kept using gemini to try fixing this for my own personal use. and it finally worked and is persistent now.

well, is this a problem that is device related? i thought that so I used another device and got same problem there. so i don't think it's device related. or it may be, i don't know honestly.

and I also tested other forks i found of kotatsu, even the og app. all of them have this problem.

i noticed this while reading manhwas from manga district source as they upload officially licensed manhwas in highest quality possible.

# Second is the technical description of the fix by Gemini ( I have no idea what this is but it fixed the problem for me ) :

## The Root Cause
 1. **Order of Operations Race Condition:** Whenever a page finishes downloading, BasePageHolder handles the PageState.Loaded or PageState.Loading state and executes ssiv.setImage(source). The underlying SubsamplingScaleImageView library completely resets its internal bitmap config pipeline during the setImage() call, wiping out the active reader configuration.
 2. **Layout Lifecycle Timing:** In continuous vertical scrolling layouts, image tiles initialize before the parent container completely finishes measuring its screen boundaries on the main thread, resulting in initial loading glitches.
## The Solution
Surgically re-apply the user's desired bitmap configuration at the exact millisecond the image mounts in the lifecycle, and ensure the scrolling container is fully measured before layout placement.
### 1. In BasePageHolder.kt
Inject settings.applyBitmapConfig(ssiv) directly before ssiv.setImage(...) in both the reload sequence and the state change listener to prevent the image engine from discarding the 32-bit setting.
### 2. In WebtoonHolder.kt
Wrap the layout initialization code inside a .post { ... } block to wait out the layout queue, ensuring the Android UI framework finishes measuring container boundaries before rendering heavy image stripes.

# I think the first one is what fixed it for me and second one is useless non-sense by Gemini?