### PR TITLE
Add nightly build variant for Usagi

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,4 @@
+import java.time.LocalDateTime
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -43,6 +44,10 @@ android {
 			minifyEnabled true
 			shrinkResources true
 			proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+		}
+		nightly {
+			initWith release
+			applicationIdSuffix = '.nightly'
 		}
 	}
 	buildFeatures {
@@ -126,6 +131,15 @@ android {
             }
 		}
 	}
+	applicationVariants.configureEach { variant ->
+		if (variant.name == 'nightly') {
+			variant.outputs.each { output ->
+				def now = LocalDateTime.now()
+				output.versionCodeOverride = now.format("yyMMdd").toInteger()
+				output.versionNameOverride = 'N' + now.format("yyyyMMdd")
+			}
+		}
+	}
 }
 dependencies {
 	implementation libs.usagi.serialization.library
@@ -201,6 +215,7 @@ dependencies {
 	implementation libs.conscrypt.android
 
 	debugImplementation libs.leakcanary.android
+	nightlyImplementation libs.leakcanary.android
 	debugImplementation libs.workinspector
 
 	testImplementation libs.junit

--- a/app/src/nightly/kotlin/org/draken/usagi/UsagiApp.kt
+++ b/app/src/nightly/kotlin/org/draken/usagi/UsagiApp.kt
@@ -1,0 +1,34 @@
+package org.draken.usagi
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import leakcanary.LeakCanary
+import org.draken.usagi.core.BaseApp
+
+class UsagiApp : BaseApp(), SharedPreferences.OnSharedPreferenceChangeListener {
+
+	override fun attachBaseContext(base: Context) {
+		super.attachBaseContext(base)
+		val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+		configureLeakCanary(isEnabled = prefs.getBoolean(KEY_LEAK_CANARY, false))
+		prefs.registerOnSharedPreferenceChangeListener(this)
+	}
+
+	override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
+		if (key == KEY_LEAK_CANARY) {
+			configureLeakCanary(sharedPreferences.getBoolean(KEY_LEAK_CANARY, false))
+		}
+	}
+
+	private fun configureLeakCanary(isEnabled: Boolean) {
+		LeakCanary.config = LeakCanary.config.copy(
+			dumpHeap = isEnabled,
+		)
+	}
+
+	private companion object {
+
+		const val KEY_LEAK_CANARY = "debug.leak_canary"
+	}
+}

--- a/app/src/nightly/res/drawable/ic_launcher_foreground_tinted.xml
+++ b/app/src/nightly/res/drawable/ic_launcher_foreground_tinted.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<bitmap
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:src="@mipmap/ic_launcher_foreground"
+    android:tint="@color/launcher_foreground_tint"
+    android:tintMode="src_in" />

--- a/app/src/nightly/res/drawable/tv_banner_foreground_tinted.xml
+++ b/app/src/nightly/res/drawable/tv_banner_foreground_tinted.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<bitmap
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:src="@mipmap/tv_banner_foreground"
+    android:tint="@color/launcher_foreground_tint"
+    android:tintMode="src_in" />

--- a/app/src/nightly/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/nightly/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_tinted" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground_tinted" />
+</adaptive-icon>

--- a/app/src/nightly/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/nightly/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_tinted" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground_tinted" />
+</adaptive-icon>

--- a/app/src/nightly/res/mipmap-anydpi-v26/tv_banner.xml
+++ b/app/src/nightly/res/mipmap-anydpi-v26/tv_banner.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/launcher_background"/>
+    <foreground android:drawable="@drawable/tv_banner_foreground_tinted"/>
+    <monochrome android:drawable="@drawable/tv_banner_foreground_tinted"/>
+</adaptive-icon>

--- a/app/src/nightly/res/values/colors.xml
+++ b/app/src/nightly/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="launcher_background">#FFFFFF</color>
+    <color name="launcher_foreground_tint">#808080</color>
+</resources>

--- a/app/src/nightly/res/values/strings.xml
+++ b/app/src/nightly/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Usagi Nightly</string>
+    <string name="channel_common_name">Usagi Nightly</string>
+</resources>


### PR DESCRIPTION
## Summary

This PR adds a **nightly** build variant to Usagi, similar to how Kotatsu implements it. It allows users to install and run a nightly version alongside the release build without conflicts.

## Changes

### Build Configuration ()
- Added `nightly` build type initialized from `release` with a `.nightly` application ID suffix
- Added dynamic versioning for nightly builds:
  - `versionCode`: `YYMMDD` format (e.g., `260803`)
  - `versionName`: `NYYYYMMDD` format (e.g., `N20260803`)
- Added LeakCanary dependency for nightly builds

### Nightly Source Set
- **`UsagiApp.kt`**: Custom Application class with configurable LeakCanary support via SharedPreferences
- **`strings.xml`**: Nightly-specific app name and notification channel name

## Benefits
- Install nightly builds alongside release builds (different app IDs)
- Automatic date-based versioning for easy tracking
- Debug tools (LeakCanary) available in nightly builds