### PR TITLE
feat: Add option to automatically transfer cookies on domain redirect

### DIFF
--- a/app/src/main/kotlin/org/draken/usagi/core/parser/MirrorSwitcher.kt
+++ b/app/src/main/kotlin/org/draken/usagi/core/parser/MirrorSwitcher.kt
@@ -5,8 +5,10 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.draken.usagi.BuildConfig
 import org.draken.usagi.core.network.MangaHttpClient
+import org.draken.usagi.core.network.cookies.MutableCookieJar
 import org.draken.usagi.core.prefs.AppSettings
 import tsuki.model.MangaSource
 import tsuki.util.await
@@ -18,6 +20,7 @@ class MirrorSwitcher
 	constructor(
 		private val settings: AppSettings,
 		@MangaHttpClient private val okHttpClient: OkHttpClient,
+		private val cookieJar: MutableCookieJar,
 	) {
 		private val blacklist = mutableSetOf<MangaSource>()
 		private val mutex: Mutex = Mutex()
@@ -44,7 +47,11 @@ class MirrorSwitcher
 				}
 				logd { "Looking for mirrors for $source..." }
 				findRedirect(repository)?.let { mirror ->
+					val oldHost = repository.domain
 					repository.domain = mirror
+					if (settings.isTransferCookiesOnRedirectEnabled) {
+						transferCookies(oldHost, mirror)
+					}
 					runCatchingCancellable {
 						loader()?.takeIfValid()
 					}.getOrNull()?.let {
@@ -93,6 +100,20 @@ class MirrorSwitcher
 				newHost
 			} else {
 				null
+			}
+		}
+
+		private fun transferCookies(oldDomain: String, newDomain: String) {
+			try {
+				val oldUrl = "https://$oldDomain".toHttpUrl()
+				val newUrl = "https://$newDomain".toHttpUrl()
+				val cookies = cookieJar.loadForRequest(oldUrl)
+				if (cookies.isNotEmpty()) {
+					cookieJar.saveFromResponse(newUrl, cookies)
+					logd { "Transferred ${cookies.size} cookies from $oldDomain to $newDomain" }
+				}
+			} catch (e: Exception) {
+				logd { "Failed to transfer cookies: ${e.message}" }
 			}
 		}
 

--- a/app/src/main/kotlin/org/draken/usagi/core/parser/MirrorSwitcher.kt
+++ b/app/src/main/kotlin/org/draken/usagi/core/parser/MirrorSwitcher.kt
@@ -104,6 +104,10 @@ class MirrorSwitcher
 		}
 
 		private fun transferCookies(oldDomain: String, newDomain: String) {
+			if (!areDomainsRelated(oldDomain, newDomain)) {
+				logd { "Skipping cookie transfer: domains not related ($oldDomain -> $newDomain)" }
+				return
+			}
 			try {
 				val oldUrl = "https://$oldDomain".toHttpUrl()
 				val newUrl = "https://$newDomain".toHttpUrl()
@@ -115,6 +119,15 @@ class MirrorSwitcher
 			} catch (e: Exception) {
 				logd { "Failed to transfer cookies: ${e.message}" }
 			}
+		}
+
+		private fun areDomainsRelated(oldDomain: String, newDomain: String): Boolean {
+			val oldParts = oldDomain.lowercase().split(".")
+			val newParts = newDomain.lowercase().split(".")
+			if (oldParts.size < 2 || newParts.size < 2) return false
+			val oldBase = oldParts.takeLast(2).joinToString(".")
+			val newBase = newParts.takeLast(2).joinToString(".")
+			return oldBase == newBase
 		}
 
 		private fun <T : Any> T.takeIfValid() =

--- a/app/src/main/kotlin/org/draken/usagi/core/parser/MirrorSwitcher.kt
+++ b/app/src/main/kotlin/org/draken/usagi/core/parser/MirrorSwitcher.kt
@@ -111,10 +111,13 @@ class MirrorSwitcher
 			try {
 				val oldUrl = "https://$oldDomain".toHttpUrl()
 				val newUrl = "https://$newDomain".toHttpUrl()
-				val cookies = cookieJar.loadForRequest(oldUrl)
-				if (cookies.isNotEmpty()) {
-					cookieJar.saveFromResponse(newUrl, cookies)
-					logd { "Transferred ${cookies.size} cookies from $oldDomain to $newDomain" }
+				val oldCookies = cookieJar.loadForRequest(oldUrl)
+				val newCookies = cookieJar.loadForRequest(newUrl)
+				val existingNames = newCookies.map { it.name }.toSet()
+				val cookiesToTransfer = oldCookies.filter { it.name !in existingNames }
+				if (cookiesToTransfer.isNotEmpty()) {
+					cookieJar.saveFromResponse(newUrl, cookiesToTransfer)
+					logd { "Transferred ${cookiesToTransfer.size} cookies from $oldDomain to $newDomain" }
 				}
 			} catch (e: Exception) {
 				logd { "Failed to transfer cookies: ${e.message}" }

--- a/app/src/main/kotlin/org/draken/usagi/core/parser/MirrorSwitcher.kt
+++ b/app/src/main/kotlin/org/draken/usagi/core/parser/MirrorSwitcher.kt
@@ -111,13 +111,10 @@ class MirrorSwitcher
 			try {
 				val oldUrl = "https://$oldDomain".toHttpUrl()
 				val newUrl = "https://$newDomain".toHttpUrl()
-				val oldCookies = cookieJar.loadForRequest(oldUrl)
-				val newCookies = cookieJar.loadForRequest(newUrl)
-				val existingNames = newCookies.map { it.name }.toSet()
-				val cookiesToTransfer = oldCookies.filter { it.name !in existingNames }
-				if (cookiesToTransfer.isNotEmpty()) {
-					cookieJar.saveFromResponse(newUrl, cookiesToTransfer)
-					logd { "Transferred ${cookiesToTransfer.size} cookies from $oldDomain to $newDomain" }
+				val cookies = cookieJar.loadForRequest(oldUrl)
+				if (cookies.isNotEmpty()) {
+					cookieJar.saveFromResponse(newUrl, cookies)
+					logd { "Transferred ${cookies.size} cookies from $oldDomain to $newDomain" }
 				}
 			} catch (e: Exception) {
 				logd { "Failed to transfer cookies: ${e.message}" }

--- a/app/src/main/kotlin/org/draken/usagi/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/draken/usagi/core/prefs/AppSettings.kt
@@ -321,6 +321,9 @@ class AppSettings
 		val isMirrorSwitchingEnabled: Boolean
 			get() = prefs.getBoolean(KEY_MIRROR_SWITCHING, false)
 
+		val isTransferCookiesOnRedirectEnabled: Boolean
+			get() = prefs.getBoolean(KEY_TRANSFER_COOKIES_ON_REDIRECT, false)
+
 		val isExitConfirmationEnabled: Boolean
 			get() = prefs.getBoolean(KEY_EXIT_CONFIRM, false)
 
@@ -884,6 +887,7 @@ class AppSettings
 			const val KEY_READER_AUTOSCROLL_SPEED = "as_speed"
 			const val KEY_READER_AUTOSCROLL_FAB = "as_fab"
 			const val KEY_MIRROR_SWITCHING = "mirror_switching"
+			const val KEY_TRANSFER_COOKIES_ON_REDIRECT = "transfer_cookies_on_redirect"
 			const val KEY_PROXY = "proxy"
 			const val KEY_PROXY_TYPE = "proxy_type_2"
 			const val KEY_PROXY_ADDRESS = "proxy_address"

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -393,6 +393,8 @@
     <string name="show_on_shelf">Hiển thị trên kệ sách</string>
     <string name="mirror_switching">Tự động chuyển sang dự phòng</string>
     <string name="mirror_switching_summary">Tự động chuyển sang tên miền dự phòng của nguồn đọc (nếu có) khi gặp lỗi</string>
+    <string name="transfer_cookies_on_redirect">Tự động chuyển cookies sang tên miền mới (beta)</string>
+    <string name="transfer_cookies_on_redirect_summary">Tự động sao chép và chuyển cookies từ tên miền cũ sang tên miền mới nếu phát hiện chuyển hướng tên miền của nguồn đọc sang tên miền khác</string>
     <string name="paused">Đã tạm dừng</string>
     <string name="images_proxy_title">Proxy tối ưu hình ảnh</string>
     <string name="images_procy_description">Sử dụng dịch vụ wsrv.nl để giảm dung lượng ảnh và tăng tốc quá trình tải ảnh nếu khả thi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -397,6 +397,8 @@
     <string name="ignore_ssl_errors">Ignore SSL errors</string>
     <string name="mirror_switching">Choose mirror automatically</string>
     <string name="mirror_switching_summary">Automatically switch domains for manga sources on errors if mirrors are available</string>
+    <string name="transfer_cookies_on_redirect">Automatically transfer cookies to the new domain (beta)</string>
+    <string name="transfer_cookies_on_redirect_summary">Automatically copy and transfer cookies from the old domain to the new domain if a redirection of the source comic\'s domain to a different domain is detected</string>
     <string name="pause">Pause</string>
     <string name="resume">Resume</string>
     <string name="paused">Paused</string>

--- a/app/src/main/res/xml/pref_sources.xml
+++ b/app/src/main/res/xml/pref_sources.xml
@@ -76,6 +76,12 @@
         app:allowDividerAbove="true" />
 
     <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="transfer_cookies_on_redirect"
+        android:summary="@string/transfer_cookies_on_redirect_summary"
+        android:title="@string/transfer_cookies_on_redirect" />
+
+    <SwitchPreferenceCompat
         android:key="handle_links"
         android:persistent="false"
         android:summary="@string/handle_links_summary"


### PR DESCRIPTION
Adds a new setting in internet settings for "Automatically transfer cookies to the new domain (beta)".

Features:
- Automatically copy and transfer cookies from old domain to new domain when redirect is detected
- Transfer happens in MirrorSwitcher when switching mirrors
- English and Vietnamese translations