### PR TITLE
feat: Import plugin via shared GitHub URL

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -211,6 +211,17 @@
 			</intent-filter>
 		</activity>
 		<activity
+			android:name="org.draken.usagi.settings.sources.ImportPluginActivity"
+			android:excludeFromRecents="true"
+			android:exported="true"
+			android:noHistory="true">
+			<intent-filter>
+				<action android:name="android.intent.action.SEND" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<data android:mimeType="text/plain" />
+			</intent-filter>
+		</activity>
+		<activity
 			android:name="org.draken.usagi.settings.reader.ReaderTapGridConfigActivity"
 			android:label="@string/reader_actions" />
 		<activity

--- a/app/src/main/kotlin/org/draken/usagi/settings/sources/ImportPluginActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/settings/sources/ImportPluginActivity.kt
@@ -1,0 +1,147 @@
+package org.draken.usagi.settings.sources
+
+import android.content.Intent
+import android.os.Bundle
+import android.text.Html
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.draken.usagi.R
+import org.draken.usagi.core.nav.AppRouter
+import org.draken.usagi.core.parser.MangaDynamicRepository
+import org.draken.usagi.settings.sources.manage.plugins.UpdatePluginsProvider
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Transparent Activity that handles shared GitHub release URLs for plugin import.
+ *
+ * When a user shares a URL like:
+ *   https://github.com/user_or_orgs/repository/releases/download/tag/plugin_name.jar
+ * with Usagi, this Activity shows a confirmation dialog and downloads the plugin.
+ */
+@AndroidEntryPoint
+class ImportPluginActivity : AppCompatActivity() {
+
+	@Inject
+	lateinit var mangaDynamicRepository: MangaDynamicRepository
+
+	@Inject
+	lateinit var updatePluginsProvider: UpdatePluginsProvider
+
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
+		if (savedInstanceState != null) {
+			finish()
+			return
+		}
+		val url = extractUrl()
+		if (url == null || !isPluginDownloadUrl(url)) {
+			Toast.makeText(this, R.string.import_plugin_url_invalid, Toast.LENGTH_SHORT).show()
+			finish()
+			return
+		}
+		val parsed = parsePluginUrl(url)
+		if (parsed == null) {
+			Toast.makeText(this, R.string.import_plugin_url_invalid, Toast.LENGTH_SHORT).show()
+			finish()
+			return
+		}
+		showConfirmDialog(parsed, url)
+	}
+
+	private fun extractUrl(): String? {
+		return when (intent.action) {
+			Intent.ACTION_SEND -> {
+				intent.getStringExtra(Intent.EXTRA_TEXT)
+					?: intent.getStringExtra(Intent.EXTRA_STREAM)
+			}
+			else -> null
+		}
+	}
+
+	private fun isPluginDownloadUrl(url: String): Boolean {
+		val trimmed = url.trim()
+		if (!trimmed.contains("github.com", ignoreCase = true)) return false
+		if (!trimmed.contains("releases", ignoreCase = true)) return false
+		if (!trimmed.endsWith(".jar", ignoreCase = true)) return false
+		return true
+	}
+
+	private fun parsePluginUrl(url: String): PluginUrlInfo? {
+		val regex = Regex(
+			"""https?://(?:www\.)?github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(.+\.jar)""",
+			RegexOption.IGNORE_CASE,
+		)
+		val match = regex.find(url.trim()) ?: return null
+		val (owner, repo, tag, fileName) = match.destructured
+		if (owner.isBlank() || repo.isBlank() || tag.isBlank() || fileName.isBlank()) return null
+		return PluginUrlInfo(
+			owner = owner,
+			repo = repo,
+			tag = tag,
+			fileName = fileName,
+			repository = "$owner/$repo",
+		)
+	}
+
+	private fun showConfirmDialog(info: PluginUrlInfo, url: String) {
+		val message = getString(
+			R.string.import_plugin_confirm,
+			info.fileName,
+			info.repository,
+		)
+		AlertDialog.Builder(this)
+			.setTitle(R.string.import_plugin_from_url)
+			.setMessage(Html.fromHtml(message))
+			.setPositiveButton(R.string.ok) { _, _ ->
+				downloadAndInstall(url, info)
+			}
+			.setNegativeButton(R.string.cancel) { _, _ ->
+				finish()
+			}
+			.setOnCancelListener {
+				finish()
+			}
+			.show()
+	}
+
+	private fun downloadAndInstall(url: String, info: PluginUrlInfo) {
+		lifecycleScope.launch {
+			val success = withContext(Dispatchers.IO) {
+				runCatching {
+					val pluginsDir = mangaDynamicRepository.getDir()
+					val outFile = File(pluginsDir, info.fileName)
+					val downloaded = updatePluginsProvider.replacePlugin(url, outFile)
+					if (!downloaded) return@runCatching false
+					updatePluginsProvider.saveDto(info.fileName, info.repository, info.tag)
+					mangaDynamicRepository.load(pluginsDir)
+					true
+				}.getOrDefault(false)
+			}
+			Toast.makeText(
+				this@ImportPluginActivity,
+				if (success) R.string.load_success else R.string.load_failed,
+				Toast.LENGTH_SHORT,
+			).show()
+			startActivity(
+				AppRouter.sourcesSettingsIntent(this@ImportPluginActivity)
+					.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+			)
+			finish()
+		}
+	}
+
+	private data class PluginUrlInfo(
+		val owner: String,
+		val repo: String,
+		val tag: String,
+		val fileName: String,
+		val repository: String,
+	)
+}

--- a/app/src/main/kotlin/org/draken/usagi/settings/sources/ImportPluginActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/settings/sources/ImportPluginActivity.kt
@@ -99,10 +99,10 @@ class ImportPluginActivity : AppCompatActivity() {
 		AlertDialog.Builder(this)
 			.setTitle(R.string.import_plugin_from_url)
 			.setMessage(Html.fromHtml(message))
-			.setPositiveButton(R.string.ok) { _, _ ->
+			.setPositiveButton(android.R.string.ok) { _, _ ->
 				downloadAndInstall(url, info)
 			}
-			.setNegativeButton(R.string.cancel) { _, _ ->
+			.setNegativeButton(android.R.string.cancel) { _, _ ->
 				finish()
 			}
 			.setOnCancelListener {

--- a/app/src/main/kotlin/org/draken/usagi/settings/sources/ImportPluginActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/settings/sources/ImportPluginActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.Html
 import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
@@ -13,23 +12,19 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.draken.usagi.R
 import org.draken.usagi.core.nav.AppRouter
-import org.draken.usagi.core.parser.MangaDynamicRepository
+import org.draken.usagi.core.ui.dialog.buildAlertDialog
 import org.draken.usagi.settings.sources.manage.plugins.UpdatePluginsProvider
-import java.io.File
 import javax.inject.Inject
 
 /**
  * Transparent Activity that handles shared GitHub release URLs for plugin import.
  *
  * When a user shares a URL like:
- *   https://github.com/user_or_orgs/repository/releases/download/tag/plugin_name.jar
+ *   https://github.com/owner/repo/releases/download/tag/plugin.jar
  * with Usagi, this Activity shows a confirmation dialog and downloads the plugin.
  */
 @AndroidEntryPoint
 class ImportPluginActivity : AppCompatActivity() {
-
-	@Inject
-	lateinit var mangaDynamicRepository: MangaDynamicRepository
 
 	@Inject
 	lateinit var updatePluginsProvider: UpdatePluginsProvider
@@ -41,18 +36,12 @@ class ImportPluginActivity : AppCompatActivity() {
 			return
 		}
 		val url = extractUrl()
-		if (url == null || !isPluginDownloadUrl(url)) {
-			Toast.makeText(this, R.string.import_plugin_url_invalid, Toast.LENGTH_SHORT).show()
+		if (url == null) {
+			Toast.makeText(this, R.string.load_failed, Toast.LENGTH_SHORT).show()
 			finish()
 			return
 		}
-		val parsed = parsePluginUrl(url)
-		if (parsed == null) {
-			Toast.makeText(this, R.string.import_plugin_url_invalid, Toast.LENGTH_SHORT).show()
-			finish()
-			return
-		}
-		showConfirmDialog(parsed, url)
+		showConfirmDialog(url)
 	}
 
 	private fun extractUrl(): String? {
@@ -65,64 +54,27 @@ class ImportPluginActivity : AppCompatActivity() {
 		}
 	}
 
-	private fun isPluginDownloadUrl(url: String): Boolean {
-		val trimmed = url.trim()
-		if (!trimmed.contains("github.com", ignoreCase = true)) return false
-		if (!trimmed.contains("releases", ignoreCase = true)) return false
-		if (!trimmed.endsWith(".jar", ignoreCase = true)) return false
-		return true
-	}
-
-	private fun parsePluginUrl(url: String): PluginUrlInfo? {
-		val regex = Regex(
-			"""https?://(?:www\.)?github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(.+\.jar)""",
-			RegexOption.IGNORE_CASE,
-		)
-		val match = regex.find(url.trim()) ?: return null
-		val (owner, repo, tag, fileName) = match.destructured
-		if (owner.isBlank() || repo.isBlank() || tag.isBlank() || fileName.isBlank()) return null
-		return PluginUrlInfo(
-			owner = owner,
-			repo = repo,
-			tag = tag,
-			fileName = fileName,
-			repository = "$owner/$repo",
-		)
-	}
-
-	private fun showConfirmDialog(info: PluginUrlInfo, url: String) {
-		val message = getString(
-			R.string.import_plugin_confirm,
-			info.fileName,
-			info.repository,
-		)
-		AlertDialog.Builder(this)
-			.setTitle(R.string.import_plugin_from_url)
-			.setMessage(Html.fromHtml(message))
-			.setPositiveButton(android.R.string.ok) { _, _ ->
-				downloadAndInstall(url, info)
+	private fun showConfirmDialog(url: String) {
+		val message = getString(R.string.import_plugin_confirm, url)
+		buildAlertDialog(this) {
+			setTitle(R.string.confirm)
+			setMessage(Html.fromHtml(message))
+			setPositiveButton(android.R.string.ok) { _, _ ->
+				importPlugin(url)
 			}
-			.setNegativeButton(android.R.string.cancel) { _, _ ->
+			setNegativeButton(android.R.string.cancel) { _, _ ->
 				finish()
 			}
-			.setOnCancelListener {
+			setOnCancelListener {
 				finish()
 			}
-			.show()
+		}.show()
 	}
 
-	private fun downloadAndInstall(url: String, info: PluginUrlInfo) {
+	private fun importPlugin(url: String) {
 		lifecycleScope.launch {
 			val success = withContext(Dispatchers.IO) {
-				runCatching {
-					val pluginsDir = mangaDynamicRepository.getDir()
-					val outFile = File(pluginsDir, info.fileName)
-					val downloaded = updatePluginsProvider.replacePlugin(url, outFile)
-					if (!downloaded) return@runCatching false
-					updatePluginsProvider.saveDto(info.fileName, info.repository, info.tag)
-					mangaDynamicRepository.load(pluginsDir)
-					true
-				}.getOrDefault(false)
+				updatePluginsProvider.importFromUrl(url)
 			}
 			Toast.makeText(
 				this@ImportPluginActivity,
@@ -136,12 +88,4 @@ class ImportPluginActivity : AppCompatActivity() {
 			finish()
 		}
 	}
-
-	private data class PluginUrlInfo(
-		val owner: String,
-		val repo: String,
-		val tag: String,
-		val fileName: String,
-		val repository: String,
-	)
 }

--- a/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/UpdatePluginsProvider.kt
+++ b/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/UpdatePluginsProvider.kt
@@ -166,6 +166,32 @@ class UpdatePluginsProvider
 			}.getOrDefault(emptyList())
 		}
 
+		/**
+		 * Parses a GitHub release download URL and installs the plugin.
+		 * URL format: https://github.com/owner/repo/releases/download/tag/file.jar
+		 */
+		suspend fun importFromUrl(url: String): Boolean {
+			val info = parseDownloadUrl(url) ?: return false
+			val release = ExternalPluginDto(
+				repository = info.repository,
+				tag = info.tag,
+				fileName = info.fileName,
+				downloadUrl = url,
+			)
+			return installPlugin(release, info.fileName)
+		}
+
+		private fun parseDownloadUrl(url: String): ParsedDownloadUrl? {
+			val match = DOWNLOAD_URL_REGEX.find(url.trim()) ?: return null
+			val (owner, repo, tag, fileName) = match.destructured
+			if (owner.isBlank() || repo.isBlank() || tag.isBlank() || fileName.isBlank()) return null
+			return ParsedDownloadUrl(
+				repository = "$owner/$repo",
+				tag = tag,
+				fileName = fileName,
+			)
+		}
+
 		fun resolve(input: String): String? {
 			val trimmed = input.trim().takeIf { it.isNotEmpty() } ?: return null
 			return (GITHUB_URL_REGEX.matchEntire(trimmed) ?: REPOSITORY_REGEX.matchEntire(trimmed))
@@ -302,5 +328,15 @@ class UpdatePluginsProvider
 				Regex(
 					"""(?i)^\s*(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?(?:/.*)?\s*$""",
 				)
+			private val DOWNLOAD_URL_REGEX = Regex(
+				"""https?://(?:www\.)?github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(.+\.jar)""",
+				RegexOption.IGNORE_CASE,
+			)
 		}
+
+		private data class ParsedDownloadUrl(
+			val repository: String,
+			val tag: String,
+			val fileName: String,
+		)
 	}

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -914,9 +914,7 @@
     <string name="overwrite_plugin_summary">Tiện ích tích hợp với tên %1$s đã được cài đặt trước đó. Thay thế nó với tiện ích này?</string>
     <string name="plugin_name">Tên tiện ích</string>
     <string name="set_plugin_name">Đặt tên cho tiện ích này</string>
-    <string name="import_plugin_from_url">Cài đặt tiện ích từ URL</string>
-    <string name="import_plugin_confirm">Bạn có muốn cài đặt tiện ích &lt;b&gt;%1$s&lt;/b&gt; từ &lt;b&gt;%2$s&lt;/b&gt;?</string>
-    <string name="import_plugin_url_invalid">URL tiện ích không hợp lệ. Vui lòng chia sẻ URL GitHub releases kết thúc bằng .jar</string>
+    <string name="import_plugin_confirm">Bạn có muốn cài đặt tiện ích từ &lt;b&gt;%1$s&lt;/b&gt;?</string>
     <string name="reader_appearance">Tùy chỉnh giao diện đọc truyện</string>
     <string name="reader_appearance_summary">Chỉnh sửa bố cục giao diện, cử chỉ hành động và điều khiển khi đọc truyện</string>
     <string name="reader_top_bar_opacity">Độ trong suốt của thanh tiêu đề</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -914,6 +914,9 @@
     <string name="overwrite_plugin_summary">Tiện ích tích hợp với tên %1$s đã được cài đặt trước đó. Thay thế nó với tiện ích này?</string>
     <string name="plugin_name">Tên tiện ích</string>
     <string name="set_plugin_name">Đặt tên cho tiện ích này</string>
+    <string name="import_plugin_from_url">Cài đặt tiện ích từ URL</string>
+    <string name="import_plugin_confirm">Bạn có muốn cài đặt tiện ích &lt;b&gt;%1$s&lt;/b&gt; từ &lt;b&gt;%2$s&lt;/b&gt;?</string>
+    <string name="import_plugin_url_invalid">URL tiện ích không hợp lệ. Vui lòng chia sẻ URL GitHub releases kết thúc bằng .jar</string>
     <string name="reader_appearance">Tùy chỉnh giao diện đọc truyện</string>
     <string name="reader_appearance_summary">Chỉnh sửa bố cục giao diện, cử chỉ hành động và điều khiển khi đọc truyện</string>
     <string name="reader_top_bar_opacity">Độ trong suốt của thanh tiêu đề</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -954,9 +954,7 @@
 	<string name="overwrite_plugin_summary">A plugin file named %1$s is already installed. Replace it with this one?</string>
 	<string name="plugin_name">Plugin name</string>
 	<string name="set_plugin_name">Set name for this plugin</string>
-	<string name="import_plugin_from_url">Import plugin from URL</string>
-	<string name="import_plugin_confirm">Do you want to import plugin &lt;b&gt;%1$s&lt;/b&gt; from &lt;b&gt;%2$s&lt;/b&gt;?</string>
-	<string name="import_plugin_url_invalid">Invalid plugin URL. Please share a GitHub releases URL ending in .jar</string>
+	<string name="import_plugin_confirm">Do you want to import this plugin from &lt;b&gt;%1$s&lt;/b&gt;?</string>
 	<string name="updates_remind">Notify about app updates</string>
 	<string name="updates_remind_summary">Show a dialog on app start when an update is available</string>
 	<string name="update_available_message">A new version of Usagi is available. Do you want to update it now?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -954,6 +954,9 @@
 	<string name="overwrite_plugin_summary">A plugin file named %1$s is already installed. Replace it with this one?</string>
 	<string name="plugin_name">Plugin name</string>
 	<string name="set_plugin_name">Set name for this plugin</string>
+	<string name="import_plugin_from_url">Import plugin from URL</string>
+	<string name="import_plugin_confirm">Do you want to import plugin &lt;b&gt;%1$s&lt;/b&gt; from &lt;b&gt;%2$s&lt;/b&gt;?</string>
+	<string name="import_plugin_url_invalid">Invalid plugin URL. Please share a GitHub releases URL ending in .jar</string>
 	<string name="updates_remind">Notify about app updates</string>
 	<string name="updates_remind_summary">Show a dialog on app start when an update is available</string>
 	<string name="update_available_message">A new version of Usagi is available. Do you want to update it now?</string>


### PR DESCRIPTION
## Summary
Adds  that handles shared GitHub release URLs for plugin import.

When a user shares a URL like:
```
https://github.com/user_or_orgs/repository/releases/download/tag/plugin_name.jar
```
with Usagi via the system share menu, a confirmation dialog appears asking if they want to import the plugin.

## Changes
- **New:** `ImportPluginActivity.kt` — transparent Activity with URL parsing, confirm dialog, and download logic
- **Modified:** `AndroidManifest.xml` — added intent-filter for `ACTION_SEND` + `text/plain`
- **Modified:** `values/strings.xml` — 3 new English strings
- **Modified:** `values-vi/strings.xml` — 3 new Vietnamese strings

## Flow
```
Share URL → System Chooser → Usagi → Parse URL → Dialog → Download → Install → Done
```

## Testing
1. Find a plugin release URL on GitHub
2. Share with Usagi via system share menu
3. Confirm dialog appears with plugin name and repo
4. Tap OK to download and install
5. Verify plugin appears in Manage Plugins list