### PR TITLE
feat: use GitHub avatar for plugins imported via GitHub

### DIFF
--- a/app/src/main/kotlin/org/draken/usagi/core/parser/favicon/FaviconFetcher.kt
+++ b/app/src/main/kotlin/org/draken/usagi/core/parser/favicon/FaviconFetcher.kt
@@ -26,6 +26,7 @@ import okio.Path.Companion.toOkioPath
 import org.draken.usagi.R
 import org.draken.usagi.core.exceptions.CloudFlareProtectedException
 import org.draken.usagi.core.model.MangaSource
+import org.draken.usagi.core.model.PluginMangaSource
 import org.draken.usagi.core.parser.EmptyMangaRepository
 import org.draken.usagi.core.parser.MangaParserRepository
 import org.draken.usagi.core.parser.MangaRepository
@@ -37,6 +38,7 @@ import org.draken.usagi.core.util.ext.toMimeTypeOrNull
 import org.draken.usagi.local.data.FaviconCache
 import org.draken.usagi.local.data.LocalMangaRepository
 import org.draken.usagi.local.data.LocalStorageCache
+import org.draken.usagi.settings.sources.manage.plugins.UpdatePluginsProvider
 import tsuki.util.runCatchingCancellable
 import java.io.File
 import javax.inject.Inject
@@ -49,9 +51,19 @@ class FaviconFetcher(
 	private val imageLoader: ImageLoader,
 	private val mangaRepositoryFactory: MangaRepository.Factory,
 	private val localStorageCache: LocalStorageCache,
+	private val updatePluginsProvider: UpdatePluginsProvider,
 ) : Fetcher {
 	override suspend fun fetch(): FetchResult? {
 		val mangaSource = MangaSource(uri.schemeSpecificPart)
+
+		// Check for GitHub avatar for plugin sources
+		if (mangaSource is PluginMangaSource) {
+			val jarName = mangaSource.jarName
+			val avatarUrl = updatePluginsProvider.getAvatarUrl(jarName)
+			if (avatarUrl != null) {
+				return imageLoader.fetch(avatarUrl, options)
+			}
+		}
 
 		return when (val repo = mangaRepositoryFactory.create(mangaSource)) {
 			is MangaParserRepository -> fetchParserFavicon(repo)
@@ -167,6 +179,7 @@ class FaviconFetcher(
 		constructor(
 			private val mangaRepositoryFactory: MangaRepository.Factory,
 			@FaviconCache private val faviconCache: LocalStorageCache,
+			private val updatePluginsProvider: UpdatePluginsProvider,
 		) : Fetcher.Factory<CoilUri> {
 			override fun create(
 				data: CoilUri,
@@ -174,7 +187,7 @@ class FaviconFetcher(
 				imageLoader: ImageLoader,
 			): Fetcher? =
 				if (data.scheme == URI_SCHEME_FAVICON) {
-					FaviconFetcher(data.toAndroidUri(), options, imageLoader, mangaRepositoryFactory, faviconCache)
+					FaviconFetcher(data.toAndroidUri(), options, imageLoader, mangaRepositoryFactory, faviconCache, updatePluginsProvider)
 				} else {
 					null
 				}

--- a/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/PluginManageAdapter.kt
+++ b/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/PluginManageAdapter.kt
@@ -3,14 +3,9 @@ package org.draken.usagi.settings.sources.manage.plugins
 import android.annotation.SuppressLint
 import android.view.View
 import androidx.core.view.isVisible
-import coil3.ImageLoader
-import coil3.request.ImageRequest
-import coil3.request.crossfade
-import coil3.toAndroidUri
 import com.hannesdorfmann.adapterdelegates4.dsl.adapterDelegateViewBinding
 import org.draken.usagi.R
 import org.draken.usagi.core.ui.BaseListAdapter
-import org.draken.usagi.core.ui.image.FaviconDrawable
 import org.draken.usagi.core.util.ext.setTextAndVisible
 import org.draken.usagi.databinding.ItemEmptyHintBinding
 import org.draken.usagi.databinding.ItemSourceConfigBinding
@@ -76,18 +71,10 @@ class PluginManageAdapter(
 				if (item.hasUpdate) View.OnClickListener { onUpdateClick(item) } else null,
 			)
 
-			// Load GitHub avatar if available
+			// Load GitHub avatar if available, otherwise use default icon
 			val avatarUrl = item.avatarUrl
 			if (avatarUrl != null) {
-				val request = ImageRequest.Builder(context)
-					.data(avatarUrl.toAndroidUri())
-					.crossfade(true)
-					.target { drawable ->
-						binding.imageViewIcon.setImageDrawable(drawable)
-						binding.imageViewIcon.background = null
-					}
-					.build()
-				ImageLoader(context).enqueue(request)
+				binding.imageViewIcon.setImageAsync(avatarUrl)
 			} else {
 				binding.imageViewIcon.setImageResource(R.drawable.ic_services)
 				binding.imageViewIcon.background = null

--- a/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/PluginManageAdapter.kt
+++ b/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/PluginManageAdapter.kt
@@ -3,9 +3,14 @@ package org.draken.usagi.settings.sources.manage.plugins
 import android.annotation.SuppressLint
 import android.view.View
 import androidx.core.view.isVisible
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.toAndroidUri
 import com.hannesdorfmann.adapterdelegates4.dsl.adapterDelegateViewBinding
 import org.draken.usagi.R
 import org.draken.usagi.core.ui.BaseListAdapter
+import org.draken.usagi.core.ui.image.FaviconDrawable
 import org.draken.usagi.core.util.ext.setTextAndVisible
 import org.draken.usagi.databinding.ItemEmptyHintBinding
 import org.draken.usagi.databinding.ItemSourceConfigBinding
@@ -70,6 +75,23 @@ class PluginManageAdapter(
 			binding.imageViewAdd.setOnClickListener(
 				if (item.hasUpdate) View.OnClickListener { onUpdateClick(item) } else null,
 			)
+
+			// Load GitHub avatar if available
+			val avatarUrl = item.avatarUrl
+			if (avatarUrl != null) {
+				val request = ImageRequest.Builder(context)
+					.data(avatarUrl.toAndroidUri())
+					.crossfade(true)
+					.target { drawable ->
+						binding.imageViewIcon.setImageDrawable(drawable)
+						binding.imageViewIcon.background = null
+					}
+					.build()
+				ImageLoader(context).enqueue(request)
+			} else {
+				binding.imageViewIcon.setImageResource(R.drawable.ic_services)
+				binding.imageViewIcon.background = null
+			}
 		}
 	}
 

--- a/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/PluginsManageViewModel.kt
+++ b/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/PluginsManageViewModel.kt
@@ -277,6 +277,7 @@ class PluginsManageViewModel
 					repository = itemMeta?.repository,
 					installedTag = itemMeta?.tag,
 					latestTag = null,
+					avatarUrl = itemMeta?.avatarUrl,
 				)
 			}
 		}

--- a/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/RemoteReleaseDto.kt
+++ b/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/RemoteReleaseDto.kt
@@ -3,4 +3,5 @@ package org.draken.usagi.settings.sources.manage.plugins
 data class RemoteReleaseDto(
 	val repository: String,
 	val tag: String,
+	val avatarUrl: String? = null,
 )

--- a/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/UpdatePluginsProvider.kt
+++ b/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/UpdatePluginsProvider.kt
@@ -63,7 +63,7 @@ class UpdatePluginsProvider
 									val release = requestRelease(info.repository, name) ?: return@async null
 									if (release.tag == info.tag) return@async null
 									if (replacePlugin(release.downloadUrl, File(pluginsDir, name))) {
-										name to RemoteReleaseDto(info.repository, release.tag)
+										name to RemoteReleaseDto(info.repository, release.tag, info.avatarUrl)
 									} else {
 										null
 									}
@@ -226,7 +226,7 @@ class UpdatePluginsProvider
 			tag: String,
 		) {
 			updateDto {
-				it[fileName] = RemoteReleaseDto(repository, tag)
+				it[fileName] = RemoteReleaseDto(repository, tag, repository.toGitHubAvatarUrl())
 			}
 		}
 
@@ -268,8 +268,11 @@ class UpdatePluginsProvider
 					val obj = json.optJSONObject(key) ?: continue
 					val repository = obj.optString(KEY_REPOSITORY)
 					val tag = obj.optString(KEY_TAG)
+					val avatarUrl =
+						obj.optString(KEY_AVATAR_URL).takeIf { it.isNotBlank() }
+							?: repository.toGitHubAvatarUrl()
 					if (repository.isNotBlank() && tag.isNotBlank()) {
-						out[key] = RemoteReleaseDto(repository, tag)
+						out[key] = RemoteReleaseDto(repository, tag, avatarUrl)
 					}
 				}
 				out
@@ -279,16 +282,23 @@ class UpdatePluginsProvider
 		fun writeDto(meta: Map<String, RemoteReleaseDto>) {
 			val json = JSONObject()
 			meta.forEach { (fileName, value) ->
-				json.put(
-					fileName,
+				val obj =
 					JSONObject()
 						.put(KEY_REPOSITORY, value.repository)
-						.put(KEY_TAG, value.tag),
-				)
+						.put(KEY_TAG, value.tag)
+				value.avatarUrl?.let { obj.put(KEY_AVATAR_URL, it) }
+				json.put(fileName, obj)
 			}
 			prefs.edit {
 				putString(PREFS_KEY, json.toString())
 			}
+		}
+
+		fun getAvatarUrl(fileName: String): String? = readDto()[fileName]?.avatarUrl
+
+		private fun String.toGitHubAvatarUrl(): String? {
+			val owner = split('/', limit = 2).firstOrNull()?.trim()
+			return if (owner.isNullOrBlank()) null else "https://github.com/$owner.png"
 		}
 
 		companion object {
@@ -296,6 +306,7 @@ class UpdatePluginsProvider
 			private const val PREFS_KEY = "github_meta"
 			private const val KEY_REPOSITORY = "repository"
 			private const val KEY_TAG = "tag"
+			private const val KEY_AVATAR_URL = "avatarUrl"
 			private const val COOLDOWN = 600000L // 10m
 			val REPOSITORY_REGEX = Regex("""^\s*([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?\s*$""")
 			val GITHUB_URL_REGEX =

--- a/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/model/PluginManageItem.kt
+++ b/app/src/main/kotlin/org/draken/usagi/settings/sources/manage/plugins/model/PluginManageItem.kt
@@ -9,6 +9,7 @@ sealed interface PluginManageItem : ListModel {
 		val repository: String?,
 		val installedTag: String?,
 		val latestTag: String?,
+		val avatarUrl: String? = null,
 	) : PluginManageItem {
 		val displayName: String
 			get() = name.removeSuffix(".jar")


### PR DESCRIPTION
## Summary

This PR adds support for using GitHub avatars as plugin logos when plugins are imported via GitHub.

## Changes

- Add `avatarUrl` field to `RemoteReleaseDto`
- Store GitHub avatar URL when installing plugins from GitHub
- Generate avatar URL from repository owner for backward compatibility
- Modify `FaviconFetcher` to use GitHub avatar for plugin sources
- Add `avatarUrl` field to `PluginManageItem.Plugin`
- Update ViewModel to populate avatarUrl from metadata
- Update adapter to load GitHub avatar using Coil in plugin management list

## How it works

1. When a plugin is imported from GitHub, the avatar URL is automatically generated from the repository owner's GitHub profile: `https://github.com/{owner}.png`
2. When loading plugin icons, `FaviconFetcher` first checks if there's a GitHub avatar URL available
3. If an avatar URL exists, it loads the GitHub avatar instead of the web favicon
4. For existing plugins without stored avatar URLs, the URL is generated on-the-fly from the repository metadata
5. In the plugin management list (Settings > Manage sources > Manage plugins), the GitHub avatar is displayed when available

## Backward Compatibility

The implementation maintains backward compatibility with existing plugins. When reading the DTO, if the `avatarUrl` is not present, it's generated from the repository URL.