### PR TITLE
feat: option to show chapters inline in details screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 /.kotlin/
 /.idea/AndroidProjectSystem.xml
 /.idea/discordrp.xml
+
+# Local research and generated documentation
+/docs/

--- a/app/src/main/kotlin/org/draken/usagi/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/draken/usagi/core/prefs/AppSettings.kt
@@ -125,6 +125,9 @@ class AppSettings
 			get() = prefs.getInt(KEY_DETAILS_BACKDROP_BLUR_AMOUNT, 60)
 			set(value) = prefs.edit { putInt(KEY_DETAILS_BACKDROP_BLUR_AMOUNT, value.coerceIn(0, 100)) }
 
+		val isChaptersInlineEnabled: Boolean
+			get() = prefs.getBoolean(KEY_DETAILS_CHAPTERS_INLINE, false)
+
 		var historyListMode: ListMode
 			get() = prefs.getEnumValue(KEY_LIST_MODE_HISTORY, listMode)
 			set(value) = prefs.edit { putEnumValue(KEY_LIST_MODE_HISTORY, value) }
@@ -942,6 +945,7 @@ class AppSettings
 			const val KEY_COLLAPSE_DESCRIPTION = "description_collapse"
 			const val KEY_DETAILS_BACKDROP = "details_backdrop"
 			const val KEY_DETAILS_BACKDROP_BLUR_AMOUNT = "details_backdrop_blur_amount"
+			const val KEY_DETAILS_CHAPTERS_INLINE = "details_chapters_inline"
 			const val KEY_BACKUP_TG_ENABLED = "backup_periodic_tg_enabled"
 			const val KEY_BACKUP_TG_CHAT = "backup_periodic_tg_chat_id"
 			const val KEY_MANGA_LIST_BADGES = "manga_list_badges"

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
@@ -30,6 +30,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.core.view.updatePaddingRelative
 import androidx.core.widget.NestedScrollView
+import androidx.fragment.app.commit
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.transition.TransitionManager
 import coil3.ImageLoader
@@ -102,6 +103,7 @@ import org.draken.usagi.details.data.ReadingTime
 import org.draken.usagi.details.service.MangaPrefetchService
 import org.draken.usagi.details.ui.model.ChapterListItem
 import org.draken.usagi.details.ui.model.HistoryInfo
+import org.draken.usagi.details.ui.pager.chapters.ChaptersFragment
 import org.draken.usagi.details.ui.scrobbling.ScrobblingItemDecoration
 import org.draken.usagi.details.ui.scrobbling.ScrollingInfoAdapter
 import org.draken.usagi.download.ui.worker.DownloadStartedObserver
@@ -148,7 +150,7 @@ class DetailsActivity :
 	private var faviconDisposable: Disposable? = null
 
 	override val bottomSheet: View?
-		get() = viewBinding.containerBottomSheet
+		get() = viewBinding.containerBottomSheet.takeIf { !settings.isChaptersInlineEnabled }
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -202,13 +204,27 @@ class DetailsActivity :
 		if (settings.isDescriptionExpanded) {
 			viewBinding.textViewDescription.maxLines = Int.MAX_VALUE - 1
 		}
-		viewBinding.containerBottomSheet?.let { sheet ->
-			sheet.setOnClickListener(this)
-			sheet.addOnLayoutChangeListener(this)
-			onBackPressedDispatcher.addCallback(BottomSheetCollapseCallback(sheet))
-			BottomSheetBehavior.from(sheet).addBottomSheetCallback(
-				DetailsBottomSheetCallback(viewBinding.swipeRefreshLayout, checkNotNull(viewBinding.navbarDim)),
-			)
+		if (settings.isChaptersInlineEnabled) {
+			viewBinding.groupChaptersInline?.isVisible = true
+			viewBinding.containerBottomSheet?.isGone = true
+			viewBinding.navbarDim?.isGone = true
+			viewBinding.containerChaptersInline?.let { container ->
+				if (supportFragmentManager.findFragmentById(container.id) == null) {
+					supportFragmentManager.commit { add(container.id, ChaptersFragment()) }
+				}
+			}
+			viewBinding.splitButtonChaptersRead?.let { splitButton ->
+				ReadButtonDelegate(splitButton, viewModel, router).attach(this)
+			}
+		} else {
+			viewBinding.containerBottomSheet?.let { sheet ->
+				sheet.setOnClickListener(this)
+				sheet.addOnLayoutChangeListener(this)
+				onBackPressedDispatcher.addCallback(BottomSheetCollapseCallback(sheet))
+				BottomSheetBehavior.from(sheet).addBottomSheetCallback(
+					DetailsBottomSheetCallback(viewBinding.swipeRefreshLayout, checkNotNull(viewBinding.navbarDim)),
+				)
+			}
 		}
 		val appRouter = router
 		viewModel.mangaDetails.filterNotNull().observe(this, ::onMangaUpdated)
@@ -222,7 +238,7 @@ class DetailsActivity :
 				DetailsErrorObserver(
 					activity = this,
 					snackbarHost = viewBinding.scrollView,
-					bottomSheet = viewBinding.containerBottomSheet,
+					bottomSheet = viewBinding.containerBottomSheet.takeIf { !settings.isChaptersInlineEnabled },
 					viewModel = viewModel,
 					resolver = exceptionResolver,
 				),
@@ -397,6 +413,7 @@ class DetailsActivity :
 		oldRight: Int,
 		oldBottom: Int,
 	) {
+		if (settings.isChaptersInlineEnabled) return
 		viewBinding.containerBottomSheet?.let { sheet ->
 			val peekHeight = BottomSheetBehavior.from(sheet).peekHeight
 			if (viewBinding.scrollView.paddingBottom != peekHeight) {
@@ -435,7 +452,9 @@ class DetailsActivity :
 			}
 			return insets.consume(v, typeMask, bottom = true, end = true)
 		} else {
-			viewBinding.navbarDim?.updateLayoutParams { height = barsInsets.bottom }
+			if (!settings.isChaptersInlineEnabled) {
+				viewBinding.navbarDim?.updateLayoutParams { height = barsInsets.bottom }
+			}
 			viewBinding.appbar.updatePadding(top = barsInsets.top)
 			viewBinding.swipeRefreshLayout.setProgressViewOffset(false, barsInsets.top, barsInsets.top + 180)
 			if (!settings.isBackdropEnabled) {

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
@@ -31,7 +31,6 @@ import androidx.core.view.updatePadding
 import androidx.core.view.updatePaddingRelative
 import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.commit
-import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.transition.TransitionManager
 import coil3.ImageLoader
@@ -183,7 +182,6 @@ class DetailsActivity :
 				viewBinding.appbar.getLocationOnScreen(loc)
 				val appBarBottom = loc[1] + viewBinding.appbar.height
 				supportActionBar?.setDisplayShowTitleEnabled(titleBottom < appBarBottom)
-				updateInlineChapterListBounds()
 			},
 		)
 		setDisplayHomeAsUp(isEnabled = true, showUpAsClose = false)
@@ -208,8 +206,6 @@ class DetailsActivity :
 		}
 		if (settings.isChaptersInlineEnabled) {
 			viewBinding.groupChaptersInline?.isVisible = true
-			viewBinding.containerChaptersInline?.addOnLayoutChangeListener(this)
-
 			viewBinding.buttonChaptersOrder?.apply {
 				isVisible = true
 				setOnClickListener {
@@ -427,37 +423,6 @@ class DetailsActivity :
 				viewBinding.scrollView.updatePadding(bottom = peekHeight)
 			}
 		}
-		updateInlineChapterListBounds()
-	}
-
-	private fun updateInlineChapterListBounds() {
-		val container = viewBinding.containerChaptersInline ?: return
-		if (!settings.isChaptersInlineEnabled || !container.isVisible) return
-		val sheet = viewBinding.containerBottomSheet ?: return
-		val location = IntArray(2)
-		val titleView = viewBinding.textViewChaptersTitle ?: return
-		titleView.getLocationOnScreen(location)
-		val titleTop = location[1]
-
-		viewBinding.appbar.getLocationOnScreen(location)
-		val appBarBottom = location[1] + viewBinding.appbar.height
-		if (titleTop > appBarBottom) {
-			container.findViewById<RecyclerView>(R.id.recyclerView_chapters)?.also { list ->
-				list.updateLayoutParams { height = ViewGroup.LayoutParams.WRAP_CONTENT }
-				list.isNestedScrollingEnabled = false
-			}
-
-			return
-		}
-		container.getLocationOnScreen(location)
-		val listTop = maxOf(location[1], appBarBottom)
-		sheet.getLocationOnScreen(location)
-		val maxHeight = (location[1] - listTop).coerceAtLeast(0)
-		container.findViewById<RecyclerView>(R.id.recyclerView_chapters)?.also { list ->
-			list.updateLayoutParams { height = maxHeight }
-			list.isNestedScrollingEnabled = maxHeight > 0
-		}
-		container.requestLayout()
 	}
 
 	override fun onApplyWindowInsets(

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
@@ -150,7 +150,7 @@ class DetailsActivity :
 	private var faviconDisposable: Disposable? = null
 
 	override val bottomSheet: View?
-		get() = viewBinding.containerBottomSheet.takeIf { !settings.isChaptersInlineEnabled }
+		get() = viewBinding.containerBottomSheet
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -206,8 +206,6 @@ class DetailsActivity :
 		}
 		if (settings.isChaptersInlineEnabled) {
 			viewBinding.groupChaptersInline?.isVisible = true
-			viewBinding.containerBottomSheet?.isGone = true
-			viewBinding.navbarDim?.isGone = true
 			viewBinding.containerChaptersInline?.let { container ->
 				if (supportFragmentManager.findFragmentById(container.id) == null) {
 					supportFragmentManager.commit { add(container.id, ChaptersFragment()) }
@@ -216,16 +214,16 @@ class DetailsActivity :
 			viewBinding.splitButtonChaptersRead?.let { splitButton ->
 				ReadButtonDelegate(splitButton, viewModel, router).attach(this)
 			}
-		} else {
-			viewBinding.containerBottomSheet?.let { sheet ->
-				sheet.setOnClickListener(this)
-				sheet.addOnLayoutChangeListener(this)
-				onBackPressedDispatcher.addCallback(BottomSheetCollapseCallback(sheet))
-				BottomSheetBehavior.from(sheet).addBottomSheetCallback(
-					DetailsBottomSheetCallback(viewBinding.swipeRefreshLayout, checkNotNull(viewBinding.navbarDim)),
-				)
-			}
 		}
+		viewBinding.containerBottomSheet?.let { sheet ->
+			sheet.setOnClickListener(this)
+			sheet.addOnLayoutChangeListener(this)
+			onBackPressedDispatcher.addCallback(BottomSheetCollapseCallback(sheet))
+			BottomSheetBehavior.from(sheet).addBottomSheetCallback(
+				DetailsBottomSheetCallback(viewBinding.swipeRefreshLayout, checkNotNull(viewBinding.navbarDim)),
+			)
+		}
+
 		val appRouter = router
 		viewModel.mangaDetails.filterNotNull().observe(this, ::onMangaUpdated)
 		viewModel.coverUrl.observe(this, ::loadCover)
@@ -238,7 +236,7 @@ class DetailsActivity :
 				DetailsErrorObserver(
 					activity = this,
 					snackbarHost = viewBinding.scrollView,
-					bottomSheet = viewBinding.containerBottomSheet.takeIf { !settings.isChaptersInlineEnabled },
+					bottomSheet = viewBinding.containerBottomSheet,
 					viewModel = viewModel,
 					resolver = exceptionResolver,
 				),
@@ -413,7 +411,6 @@ class DetailsActivity :
 		oldRight: Int,
 		oldBottom: Int,
 	) {
-		if (settings.isChaptersInlineEnabled) return
 		viewBinding.containerBottomSheet?.let { sheet ->
 			val peekHeight = BottomSheetBehavior.from(sheet).peekHeight
 			if (viewBinding.scrollView.paddingBottom != peekHeight) {
@@ -452,9 +449,8 @@ class DetailsActivity :
 			}
 			return insets.consume(v, typeMask, bottom = true, end = true)
 		} else {
-			if (!settings.isChaptersInlineEnabled) {
-				viewBinding.navbarDim?.updateLayoutParams { height = barsInsets.bottom }
-			}
+			viewBinding.navbarDim?.updateLayoutParams { height = barsInsets.bottom }
+
 			viewBinding.appbar.updatePadding(top = barsInsets.top)
 			viewBinding.swipeRefreshLayout.setProgressViewOffset(false, barsInsets.top, barsInsets.top + 180)
 			if (!settings.isBackdropEnabled) {

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
@@ -31,6 +31,7 @@ import androidx.core.view.updatePadding
 import androidx.core.view.updatePaddingRelative
 import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.commit
+import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.transition.TransitionManager
 import coil3.ImageLoader
@@ -182,6 +183,7 @@ class DetailsActivity :
 				viewBinding.appbar.getLocationOnScreen(loc)
 				val appBarBottom = loc[1] + viewBinding.appbar.height
 				supportActionBar?.setDisplayShowTitleEnabled(titleBottom < appBarBottom)
+				updateInlineChapterListBounds()
 			},
 		)
 		setDisplayHomeAsUp(isEnabled = true, showUpAsClose = false)
@@ -206,6 +208,8 @@ class DetailsActivity :
 		}
 		if (settings.isChaptersInlineEnabled) {
 			viewBinding.groupChaptersInline?.isVisible = true
+			viewBinding.containerChaptersInline?.addOnLayoutChangeListener(this)
+
 			viewBinding.buttonChaptersOrder?.apply {
 				isVisible = true
 				setOnClickListener {
@@ -423,6 +427,37 @@ class DetailsActivity :
 				viewBinding.scrollView.updatePadding(bottom = peekHeight)
 			}
 		}
+		updateInlineChapterListBounds()
+	}
+
+	private fun updateInlineChapterListBounds() {
+		val container = viewBinding.containerChaptersInline ?: return
+		if (!settings.isChaptersInlineEnabled || !container.isVisible) return
+		val sheet = viewBinding.containerBottomSheet ?: return
+		val location = IntArray(2)
+		val titleView = viewBinding.textViewChaptersTitle ?: return
+		titleView.getLocationOnScreen(location)
+		val titleTop = location[1]
+
+		viewBinding.appbar.getLocationOnScreen(location)
+		val appBarBottom = location[1] + viewBinding.appbar.height
+		if (titleTop > appBarBottom) {
+			container.findViewById<RecyclerView>(R.id.recyclerView_chapters)?.also { list ->
+				list.updateLayoutParams { height = ViewGroup.LayoutParams.WRAP_CONTENT }
+				list.isNestedScrollingEnabled = false
+			}
+
+			return
+		}
+		container.getLocationOnScreen(location)
+		val listTop = maxOf(location[1], appBarBottom)
+		sheet.getLocationOnScreen(location)
+		val maxHeight = (location[1] - listTop).coerceAtLeast(0)
+		container.findViewById<RecyclerView>(R.id.recyclerView_chapters)?.also { list ->
+			list.updateLayoutParams { height = maxHeight }
+			list.isNestedScrollingEnabled = maxHeight > 0
+		}
+		container.requestLayout()
 	}
 
 	override fun onApplyWindowInsets(

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
@@ -206,6 +206,15 @@ class DetailsActivity :
 		}
 		if (settings.isChaptersInlineEnabled) {
 			viewBinding.groupChaptersInline?.isVisible = true
+			viewBinding.buttonChaptersOrder?.apply {
+				isVisible = true
+				setOnClickListener {
+					viewModel.setChaptersReversed(viewModel.isChaptersReversed.value != true)
+				}
+				viewModel.isChaptersReversed.observe(this@DetailsActivity) { reversed ->
+					setText(if (reversed) R.string.newest else R.string.order_oldest)
+				}
+			}
 			viewBinding.containerChaptersInline?.let { container ->
 				if (supportFragmentManager.findFragmentById(container.id) == null) {
 					supportFragmentManager.commit { add(container.id, ChaptersFragment()) }

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
@@ -211,9 +211,7 @@ class DetailsActivity :
 					supportFragmentManager.commit { add(container.id, ChaptersFragment()) }
 				}
 			}
-			viewBinding.splitButtonChaptersRead?.let { splitButton ->
-				ReadButtonDelegate(splitButton, viewModel, router).attach(this)
-			}
+			viewBinding.splitButtonChaptersRead?.isGone = true
 		}
 		viewBinding.containerBottomSheet?.let { sheet ->
 			sheet.setOnClickListener(this)

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsActivity.kt
@@ -211,7 +211,6 @@ class DetailsActivity :
 					supportFragmentManager.commit { add(container.id, ChaptersFragment()) }
 				}
 			}
-			viewBinding.splitButtonChaptersRead?.isGone = true
 		}
 		viewBinding.containerBottomSheet?.let { sheet ->
 			sheet.setOnClickListener(this)

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
@@ -26,7 +26,6 @@ import androidx.core.view.updatePadding
 import androidx.core.view.updatePaddingRelative
 import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.commit
-import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.transition.TransitionManager
 import coil3.ImageLoader
@@ -190,13 +189,11 @@ class DetailsClassicActivity :
 					appbar.getLocationOnScreen(loc)
 					val appBarBottom = loc[1] + appbar.height
 					supportActionBar?.setDisplayShowTitleEnabled(titleBottom < appBarBottom)
-					updateInlineChapterListBounds()
 				},
 			)
 			if (settings.isChaptersInlineEnabled) {
 				buttonRead.isGone = true
 				groupChaptersInline?.isVisible = true
-				containerChaptersInline?.addOnLayoutChangeListener(this@DetailsClassicActivity)
 				buttonChaptersOrder?.apply {
 					isVisible = true
 					setOnClickListener {
@@ -474,35 +471,6 @@ class DetailsClassicActivity :
 		viewBinding.run {
 			buttonDescriptionMore.isVisible = textViewDescription.isTextTruncated
 		}
-		updateInlineChapterListBounds()
-	}
-
-	private fun updateInlineChapterListBounds() {
-		val container = viewBinding.containerChaptersInline ?: return
-		if (!settings.isChaptersInlineEnabled || !container.isVisible) return
-		val sheet = viewBinding.containerBottomSheet
-		val location = IntArray(2)
-		val titleView = viewBinding.textViewChaptersTitle ?: return
-		titleView.getLocationOnScreen(location)
-		val titleTop = location[1]
-		viewBinding.appbar.getLocationOnScreen(location)
-		val appBarBottom = location[1] + viewBinding.appbar.height
-		if (titleTop > appBarBottom) {
-			container.findViewById<RecyclerView>(R.id.recyclerView_chapters)?.also { list ->
-				list.updateLayoutParams { height = ViewGroup.LayoutParams.WRAP_CONTENT }
-				list.isNestedScrollingEnabled = false
-			}
-			return
-		}
-		container.getLocationOnScreen(location)
-		val listTop = maxOf(location[1], appBarBottom)
-		sheet.getLocationOnScreen(location)
-		val maxHeight = (location[1] - listTop).coerceAtLeast(0)
-		container.findViewById<RecyclerView>(R.id.recyclerView_chapters)?.also { list ->
-			list.updateLayoutParams { height = maxHeight }
-			list.isNestedScrollingEnabled = maxHeight > 0
-		}
-		container.requestLayout()
 	}
 
 	override fun onApplyWindowInsets(

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
@@ -25,6 +25,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.core.view.updatePaddingRelative
 import androidx.core.widget.NestedScrollView
+import androidx.fragment.app.commit
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.transition.TransitionManager
 import coil3.ImageLoader
@@ -87,6 +88,7 @@ import org.draken.usagi.details.data.MangaDetails
 import org.draken.usagi.details.service.MangaPrefetchService
 import org.draken.usagi.details.ui.model.ChapterListItem
 import org.draken.usagi.details.ui.model.HistoryInfo
+import org.draken.usagi.details.ui.pager.chapters.ChaptersFragment
 import org.draken.usagi.details.ui.scrobbling.ScrobblingItemDecoration
 import org.draken.usagi.details.ui.scrobbling.ScrollingInfoAdapter
 import org.draken.usagi.download.ui.worker.DownloadStartedObserver
@@ -130,8 +132,8 @@ class DetailsClassicActivity :
 	private var statusBarInset: Int = 0
 	private var faviconDisposable: Disposable? = null
 
-	override val bottomSheet: View
-		get() = viewBinding.containerBottomSheet
+	override val bottomSheet: View?
+		get() = viewBinding.containerBottomSheet.takeIf { !settings.isChaptersInlineEnabled }
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -189,10 +191,21 @@ class DetailsClassicActivity :
 					supportActionBar?.setDisplayShowTitleEnabled(titleBottom < appBarBottom)
 				},
 			)
-			containerBottomSheet.let { sheet ->
-				val behavior = (sheet.layoutParams as? CoordinatorLayout.LayoutParams)?.behavior as? BottomSheetBehavior<*>
-				if (behavior != null) {
-					onBackPressedDispatcher.addCallback(BottomSheetCollapseCallback(sheet, behavior))
+			if (settings.isChaptersInlineEnabled) {
+				containerBottomSheet.isGone = true
+				navbarDim?.isGone = true
+				groupChaptersInline?.isVisible = true
+				containerChaptersInline?.let { container ->
+					if (supportFragmentManager.findFragmentById(container.id) == null) {
+						supportFragmentManager.commit { add(container.id, ChaptersFragment()) }
+					}
+				}
+			} else {
+				containerBottomSheet.let { sheet ->
+					val behavior = (sheet.layoutParams as? CoordinatorLayout.LayoutParams)?.behavior as? BottomSheetBehavior<*>
+					if (behavior != null) {
+						onBackPressedDispatcher.addCallback(BottomSheetCollapseCallback(sheet, behavior))
+					}
 				}
 			}
 		}
@@ -209,7 +222,7 @@ class DetailsClassicActivity :
 				DetailsErrorObserver(
 					activity = this,
 					snackbarHost = viewBinding.scrollView,
-					bottomSheet = viewBinding.containerBottomSheet,
+					bottomSheet = viewBinding.containerBottomSheet.takeIf { !settings.isChaptersInlineEnabled },
 					viewModel = viewModel,
 					resolver = exceptionResolver,
 				),
@@ -490,11 +503,18 @@ class DetailsClassicActivity :
 			}
 			return insets.consume(v, typeMask, bottom = true, end = true)
 		} else {
-			viewBinding.navbarDim?.updateLayoutParams { height = barsInsets.bottom }
-			viewBinding.scrollView.updatePadding(
-				top = actionBarSize + barsInsets.top,
-				bottom = barsInsets.bottom + resources.getDimensionPixelOffset(R.dimen.details_bs_peek_height),
-			)
+			if (settings.isChaptersInlineEnabled) {
+				viewBinding.scrollView.updatePadding(
+					top = actionBarSize + barsInsets.top,
+					bottom = barsInsets.bottom,
+				)
+			} else {
+				viewBinding.navbarDim?.updateLayoutParams { height = barsInsets.bottom }
+				viewBinding.scrollView.updatePadding(
+					top = actionBarSize + barsInsets.top,
+					bottom = barsInsets.bottom + resources.getDimensionPixelOffset(R.dimen.details_bs_peek_height),
+				)
+			}
 			if (!settings.isBackdropEnabled) {
 				viewBinding.contentContainer.updateLayoutParams<ViewGroup.MarginLayoutParams> {
 					topMargin = resources.getDimensionPixelOffset(R.dimen.margin_normal)

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
@@ -26,6 +26,7 @@ import androidx.core.view.updatePadding
 import androidx.core.view.updatePaddingRelative
 import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.commit
+import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.transition.TransitionManager
 import coil3.ImageLoader
@@ -189,11 +190,13 @@ class DetailsClassicActivity :
 					appbar.getLocationOnScreen(loc)
 					val appBarBottom = loc[1] + appbar.height
 					supportActionBar?.setDisplayShowTitleEnabled(titleBottom < appBarBottom)
+					updateInlineChapterListBounds()
 				},
 			)
 			if (settings.isChaptersInlineEnabled) {
 				buttonRead.isGone = true
 				groupChaptersInline?.isVisible = true
+				containerChaptersInline?.addOnLayoutChangeListener(this@DetailsClassicActivity)
 				buttonChaptersOrder?.apply {
 					isVisible = true
 					setOnClickListener {
@@ -471,6 +474,35 @@ class DetailsClassicActivity :
 		viewBinding.run {
 			buttonDescriptionMore.isVisible = textViewDescription.isTextTruncated
 		}
+		updateInlineChapterListBounds()
+	}
+
+	private fun updateInlineChapterListBounds() {
+		val container = viewBinding.containerChaptersInline ?: return
+		if (!settings.isChaptersInlineEnabled || !container.isVisible) return
+		val sheet = viewBinding.containerBottomSheet
+		val location = IntArray(2)
+		val titleView = viewBinding.textViewChaptersTitle ?: return
+		titleView.getLocationOnScreen(location)
+		val titleTop = location[1]
+		viewBinding.appbar.getLocationOnScreen(location)
+		val appBarBottom = location[1] + viewBinding.appbar.height
+		if (titleTop > appBarBottom) {
+			container.findViewById<RecyclerView>(R.id.recyclerView_chapters)?.also { list ->
+				list.updateLayoutParams { height = ViewGroup.LayoutParams.WRAP_CONTENT }
+				list.isNestedScrollingEnabled = false
+			}
+			return
+		}
+		container.getLocationOnScreen(location)
+		val listTop = maxOf(location[1], appBarBottom)
+		sheet.getLocationOnScreen(location)
+		val maxHeight = (location[1] - listTop).coerceAtLeast(0)
+		container.findViewById<RecyclerView>(R.id.recyclerView_chapters)?.also { list ->
+			list.updateLayoutParams { height = maxHeight }
+			list.isNestedScrollingEnabled = maxHeight > 0
+		}
+		container.requestLayout()
 	}
 
 	override fun onApplyWindowInsets(

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
@@ -194,6 +194,15 @@ class DetailsClassicActivity :
 			if (settings.isChaptersInlineEnabled) {
 				buttonRead.isGone = true
 				groupChaptersInline?.isVisible = true
+				buttonChaptersOrder?.apply {
+					isVisible = true
+					setOnClickListener {
+						viewModel.setChaptersReversed(viewModel.isChaptersReversed.value != true)
+					}
+					viewModel.isChaptersReversed.observe(this@DetailsClassicActivity) { reversed ->
+						setText(if (reversed) R.string.newest else R.string.order_oldest)
+					}
+				}
 				containerChaptersInline?.let { container ->
 					if (supportFragmentManager.findFragmentById(container.id) == null) {
 						supportFragmentManager.commit { add(container.id, ChaptersFragment()) }

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
@@ -192,6 +192,7 @@ class DetailsClassicActivity :
 				},
 			)
 			if (settings.isChaptersInlineEnabled) {
+				buttonRead.isGone = true
 				groupChaptersInline?.isVisible = true
 				containerChaptersInline?.let { container ->
 					if (supportFragmentManager.findFragmentById(container.id) == null) {

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/DetailsClassicActivity.kt
@@ -133,7 +133,7 @@ class DetailsClassicActivity :
 	private var faviconDisposable: Disposable? = null
 
 	override val bottomSheet: View?
-		get() = viewBinding.containerBottomSheet.takeIf { !settings.isChaptersInlineEnabled }
+		get() = viewBinding.containerBottomSheet
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -192,20 +192,17 @@ class DetailsClassicActivity :
 				},
 			)
 			if (settings.isChaptersInlineEnabled) {
-				containerBottomSheet.isGone = true
-				navbarDim?.isGone = true
 				groupChaptersInline?.isVisible = true
 				containerChaptersInline?.let { container ->
 					if (supportFragmentManager.findFragmentById(container.id) == null) {
 						supportFragmentManager.commit { add(container.id, ChaptersFragment()) }
 					}
 				}
-			} else {
-				containerBottomSheet.let { sheet ->
-					val behavior = (sheet.layoutParams as? CoordinatorLayout.LayoutParams)?.behavior as? BottomSheetBehavior<*>
-					if (behavior != null) {
-						onBackPressedDispatcher.addCallback(BottomSheetCollapseCallback(sheet, behavior))
-					}
+			}
+			containerBottomSheet.let { sheet ->
+				val behavior = (sheet.layoutParams as? CoordinatorLayout.LayoutParams)?.behavior as? BottomSheetBehavior<*>
+				if (behavior != null) {
+					onBackPressedDispatcher.addCallback(BottomSheetCollapseCallback(sheet, behavior))
 				}
 			}
 		}
@@ -222,7 +219,7 @@ class DetailsClassicActivity :
 				DetailsErrorObserver(
 					activity = this,
 					snackbarHost = viewBinding.scrollView,
-					bottomSheet = viewBinding.containerBottomSheet.takeIf { !settings.isChaptersInlineEnabled },
+					bottomSheet = viewBinding.containerBottomSheet,
 					viewModel = viewModel,
 					resolver = exceptionResolver,
 				),
@@ -503,18 +500,12 @@ class DetailsClassicActivity :
 			}
 			return insets.consume(v, typeMask, bottom = true, end = true)
 		} else {
-			if (settings.isChaptersInlineEnabled) {
-				viewBinding.scrollView.updatePadding(
-					top = actionBarSize + barsInsets.top,
-					bottom = barsInsets.bottom,
-				)
-			} else {
-				viewBinding.navbarDim?.updateLayoutParams { height = barsInsets.bottom }
-				viewBinding.scrollView.updatePadding(
-					top = actionBarSize + barsInsets.top,
-					bottom = barsInsets.bottom + resources.getDimensionPixelOffset(R.dimen.details_bs_peek_height),
-				)
-			}
+			viewBinding.navbarDim?.updateLayoutParams { height = barsInsets.bottom }
+			viewBinding.scrollView.updatePadding(
+				top = actionBarSize + barsInsets.top,
+				bottom = barsInsets.bottom + resources.getDimensionPixelOffset(R.dimen.details_bs_peek_height),
+			)
+
 			if (!settings.isBackdropEnabled) {
 				viewBinding.contentContainer.updateLayoutParams<ViewGroup.MarginLayoutParams> {
 					topMargin = resources.getDimensionPixelOffset(R.dimen.margin_normal)

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/pager/ChapterPagesMenuProvider.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/pager/ChapterPagesMenuProvider.kt
@@ -140,10 +140,7 @@ class ChapterPagesMenuProvider(
 	}
 
 	private fun getCurrentTab(): Int {
-		var page = pager.currentItem
-		if (page > 0 && pager.adapter?.itemCount == 2) { // no Pages page
-			page++ // shift
-		}
-		return page
+		val adapter = pager.adapter as? ChaptersPagesAdapter ?: return TAB_CHAPTERS
+		return adapter.tabIdAt(pager.currentItem)
 	}
 }

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/pager/ChaptersPagesAdapter.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/pager/ChaptersPagesAdapter.kt
@@ -13,40 +13,58 @@ class ChaptersPagesAdapter(
 	fragment: Fragment,
 	val isPagesTabEnabled: Boolean,
 	private val isClassicUi: Boolean,
+	val isChaptersTabEnabled: Boolean = true,
 ) : FragmentStateAdapter(fragment),
 	TabLayoutMediator.TabConfigurationStrategy {
-	override fun getItemCount(): Int = if (isPagesTabEnabled) 3 else 2
+	private val tabIds =
+		buildList {
+			if (isChaptersTabEnabled) add(ChaptersPagesSheet.TAB_CHAPTERS)
+			if (isPagesTabEnabled) add(ChaptersPagesSheet.TAB_PAGES)
+			add(ChaptersPagesSheet.TAB_BOOKMARKS)
+		}
+
+	override fun getItemCount(): Int = tabIds.size
 
 	override fun createFragment(position: Int): Fragment =
-		when (position) {
-			0 -> ChaptersFragment()
-			1 -> if (isPagesTabEnabled) PagesFragment() else BookmarksFragment()
-			2 -> BookmarksFragment()
-			else -> throw IllegalArgumentException("Invalid position $position")
+		when (tabIds[position]) {
+			ChaptersPagesSheet.TAB_CHAPTERS -> ChaptersFragment()
+			ChaptersPagesSheet.TAB_PAGES -> PagesFragment()
+			ChaptersPagesSheet.TAB_BOOKMARKS -> BookmarksFragment()
+			else -> error("Invalid tab ${tabIds[position]}")
 		}
 
 	override fun onConfigureTab(
 		tab: TabLayout.Tab,
 		position: Int,
 	) {
-		if (isClassicUi) {
-			tab.setText(
-				when (position) {
-					0 -> R.string.chapters
-					1 -> if (isPagesTabEnabled) R.string.pages else R.string.bookmarks
-					2 -> R.string.bookmarks
-					else -> 0
-				},
-			)
-		} else {
-			tab.setIcon(
-				when (position) {
-					0 -> R.drawable.ic_list
-					1 -> if (isPagesTabEnabled) R.drawable.ic_grid else R.drawable.ic_bookmark
-					2 -> R.drawable.ic_bookmark
-					else -> 0
-				},
-			)
+		when (tabIds[position]) {
+			ChaptersPagesSheet.TAB_CHAPTERS -> {
+				if (isClassicUi) {
+					tab.setText(R.string.chapters)
+				} else {
+					tab.setIcon(R.drawable.ic_list)
+				}
+			}
+
+			ChaptersPagesSheet.TAB_PAGES -> {
+				if (isClassicUi) {
+					tab.setText(R.string.pages)
+				} else {
+					tab.setIcon(R.drawable.ic_grid)
+				}
+			}
+
+			ChaptersPagesSheet.TAB_BOOKMARKS -> {
+				if (isClassicUi) {
+					tab.setText(R.string.bookmarks)
+				} else {
+					tab.setIcon(R.drawable.ic_bookmark)
+				}
+			}
 		}
 	}
+
+	fun indexOfTab(tabId: Int): Int = tabIds.indexOf(tabId).takeIf { it >= 0 } ?: 0
+
+	fun tabIdAt(position: Int): Int = tabIds[position]
 }

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/pager/ChaptersPagesSheet.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/pager/ChaptersPagesSheet.kt
@@ -38,6 +38,7 @@ import org.draken.usagi.databinding.SheetChaptersPagesBinding
 import org.draken.usagi.details.ui.DetailsViewModel
 import org.draken.usagi.details.ui.ReadButtonDelegate
 import org.draken.usagi.download.ui.worker.DownloadStartedObserver
+import org.draken.usagi.main.ui.owners.BottomSheetOwner
 import javax.inject.Inject
 import androidx.appcompat.R as appcompatR
 
@@ -66,11 +67,15 @@ class ChaptersPagesSheet :
 
 		val args = arguments ?: Bundle.EMPTY
 		val isClassicUi = settings.detailsUiMode == DetailsUiMode.CLASSIC
-		var defaultTab = args.getInt(AppRouter.KEY_TAB, settings.defaultDetailsTab)
-		val adapter = ChaptersPagesAdapter(this, settings.isPagesTabEnabled, isClassicUi)
-		if (!adapter.isPagesTabEnabled) {
-			defaultTab = (defaultTab - 1).coerceAtLeast(TAB_CHAPTERS)
-		}
+		val isInlineDetailsSheet = settings.isChaptersInlineEnabled && activity is BottomSheetOwner
+		val adapter =
+			ChaptersPagesAdapter(
+				this,
+				settings.isPagesTabEnabled,
+				isClassicUi,
+				isChaptersTabEnabled = !isInlineDetailsSheet,
+			)
+		val defaultTab = adapter.indexOfTab(args.getInt(AppRouter.KEY_TAB, settings.defaultDetailsTab))
 		(viewModel as? DetailsViewModel)?.let { dvm ->
 			if (isClassicUi) {
 				binding.splitButtonRead.isVisible = false
@@ -193,11 +198,14 @@ class ChaptersPagesSheet :
 
 	private fun onPageChanged(position: Int) {
 		viewBinding?.toolbar?.invalidateMenu()
-		settings.lastDetailsTab = position
+		val adapter = viewBinding?.pager?.adapter as? ChaptersPagesAdapter
+		settings.lastDetailsTab = adapter?.tabIdAt(position) ?: position
 	}
 
 	private fun onNewChaptersChanged(counter: Int) {
-		val tab = viewBinding?.tabs?.getTabAt(0) ?: return
+		val adapter = viewBinding?.pager?.adapter as? ChaptersPagesAdapter ?: return
+		if (!adapter.isChaptersTabEnabled) return
+		val tab = viewBinding?.tabs?.getTabAt(adapter.indexOfTab(TAB_CHAPTERS)) ?: return
 		if (counter == 0) {
 			tab.removeBadge()
 		} else {

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
@@ -103,7 +103,9 @@ class ChaptersFragment :
 			addItemDecoration(TypedListSpacingDecoration(context, true))
 			checkNotNull(selectionController).attachToRecyclerView(this)
 			setHasFixedSize(!isInline)
-			PagerNestedScrollHelper(this).bind(viewLifecycleOwner)
+			if (!isInline) {
+				PagerNestedScrollHelper(this).bind(viewLifecycleOwner)
+			}
 			adapter = chaptersAdapter
 			ChapterGridSpanHelper.attach(this)
 		}

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
@@ -93,16 +93,16 @@ class ChaptersFragment :
 				(binding.root.layoutParams ?: ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)).apply {
 					height = ViewGroup.LayoutParams.WRAP_CONTENT
 				}
-			binding.recyclerViewChapters.layoutParams =
-				(binding.recyclerViewChapters.layoutParams ?: ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)).apply {
-					height = ViewGroup.LayoutParams.WRAP_CONTENT
-				}
+			(binding.recyclerViewChapters.layoutParams as? android.widget.RelativeLayout.LayoutParams)?.apply {
+				height = ViewGroup.LayoutParams.WRAP_CONTENT
+				removeRule(android.widget.RelativeLayout.ALIGN_PARENT_BOTTOM)
+			}
 			binding.recyclerViewChapters.isNestedScrollingEnabled = false
 		}
 		with(binding.recyclerViewChapters) {
 			addItemDecoration(TypedListSpacingDecoration(context, true))
 			checkNotNull(selectionController).attachToRecyclerView(this)
-			setHasFixedSize(true)
+			setHasFixedSize(!isInline)
 			PagerNestedScrollHelper(this).bind(viewLifecycleOwner)
 			adapter = chaptersAdapter
 			ChapterGridSpanHelper.attach(this)

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -89,6 +90,7 @@ class ChaptersFragment :
 				}
 		}
 		if (isInline) {
+			setupInlineOrderButton()
 			binding.root.layoutParams =
 				(binding.root.layoutParams ?: ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)).apply {
 					height = ViewGroup.LayoutParams.WRAP_CONTENT
@@ -185,6 +187,17 @@ class ChaptersFragment :
 			)
 		}
 		return WindowInsetsCompat.CONSUMED
+	}
+
+	private fun setupInlineOrderButton() {
+		val orderButton = requireActivity().findViewById<TextView>(R.id.button_chapters_order) ?: return
+		orderButton.isVisible = true
+		orderButton.setOnClickListener {
+			viewModel.setChaptersReversed(viewModel.isChaptersReversed.value != true)
+		}
+		viewModel.isChaptersReversed.observe(viewLifecycleOwner) { reversed ->
+			orderButton.setText(if (reversed) R.string.newest else R.string.order_oldest)
+		}
 	}
 
 	private fun onChaptersChanged(list: List<ListModel>) {

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
@@ -103,9 +103,7 @@ class ChaptersFragment :
 			addItemDecoration(TypedListSpacingDecoration(context, true))
 			checkNotNull(selectionController).attachToRecyclerView(this)
 			setHasFixedSize(!isInline)
-			if (!isInline) {
-				PagerNestedScrollHelper(this).bind(viewLifecycleOwner)
-			}
+			PagerNestedScrollHelper(this).bind(viewLifecycleOwner)
 			adapter = chaptersAdapter
 			ChapterGridSpanHelper.attach(this)
 		}

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
@@ -69,6 +69,7 @@ class ChaptersFragment :
 	) {
 		super.onViewBindingCreated(binding, savedInstanceState)
 		val isClassic = activity is org.draken.usagi.details.ui.DetailsClassicActivity
+		val isInline = parentFragment == null
 		chaptersAdapter = ChaptersAdapter(this)
 		selectionController =
 			ListSelectionController(
@@ -86,6 +87,17 @@ class ChaptersFragment :
 				} else {
 					LinearLayoutManager(context)
 				}
+		}
+		if (isInline) {
+			binding.root.layoutParams =
+				(binding.root.layoutParams ?: ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)).apply {
+					height = ViewGroup.LayoutParams.WRAP_CONTENT
+				}
+			binding.recyclerViewChapters.layoutParams =
+				(binding.recyclerViewChapters.layoutParams ?: ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)).apply {
+					height = ViewGroup.LayoutParams.WRAP_CONTENT
+				}
+			binding.recyclerViewChapters.isNestedScrollingEnabled = false
 		}
 		with(binding.recyclerViewChapters) {
 			addItemDecoration(TypedListSpacingDecoration(context, true))

--- a/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
+++ b/app/src/main/kotlin/org/draken/usagi/details/ui/pager/chapters/ChaptersFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -90,7 +89,6 @@ class ChaptersFragment :
 				}
 		}
 		if (isInline) {
-			setupInlineOrderButton()
 			binding.root.layoutParams =
 				(binding.root.layoutParams ?: ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)).apply {
 					height = ViewGroup.LayoutParams.WRAP_CONTENT
@@ -187,17 +185,6 @@ class ChaptersFragment :
 			)
 		}
 		return WindowInsetsCompat.CONSUMED
-	}
-
-	private fun setupInlineOrderButton() {
-		val orderButton = requireActivity().findViewById<TextView>(R.id.button_chapters_order) ?: return
-		orderButton.isVisible = true
-		orderButton.setOnClickListener {
-			viewModel.setChaptersReversed(viewModel.isChaptersReversed.value != true)
-		}
-		viewModel.isChaptersReversed.observe(viewLifecycleOwner) { reversed ->
-			orderButton.setText(if (reversed) R.string.newest else R.string.order_oldest)
-		}
 	}
 
 	private fun onChaptersChanged(list: List<ListModel>) {

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -349,36 +349,11 @@
 						android:singleLine="true"
 						android:text="@string/chapters"
 						android:textAppearance="?textAppearanceTitleSmall"
-						app:layout_constraintEnd_toStartOf="@id/split_button_chapters_read"
+						app:layout_constraintEnd_toEndOf="parent"
 						app:layout_constraintStart_toStartOf="parent"
 						app:layout_constraintTop_toBottomOf="@id/recyclerView_related" />
 
-					<com.google.android.material.button.MaterialSplitButton
-						android:id="@+id/split_button_chapters_read"
-						android:layout_width="wrap_content"
-						android:layout_height="wrap_content"
-						android:layout_marginEnd="8dp"
-						app:layout_constraintBaseline_toBaselineOf="@id/textView_chapters_title"
-						app:layout_constraintEnd_toEndOf="parent">
 
-						<Button
-							android:id="@+id/button_read"
-							style="?materialSplitButtonLeadingFilledStyle"
-							android:layout_width="wrap_content"
-							android:layout_height="wrap_content"
-							android:minWidth="@dimen/read_button_min_width"
-							android:text="@string/read" />
-
-						<Button
-							android:id="@+id/button_read_menu"
-							style="?materialSplitButtonIconFilledStyle"
-							android:layout_width="wrap_content"
-							android:layout_height="wrap_content"
-							android:contentDescription="@string/show_menu"
-							app:icon="?expandCollapseIndicator"
-							app:toggleCheckedStateOnClick="false" />
-
-					</com.google.android.material.button.MaterialSplitButton>
 
 					<androidx.fragment.app.FragmentContainerView
 						android:id="@+id/container_chapters_inline"
@@ -393,7 +368,7 @@
 						android:layout_width="wrap_content"
 						android:layout_height="wrap_content"
 						android:visibility="gone"
-						app:constraint_referenced_ids="container_chapters_inline,textView_chapters_title,split_button_chapters_read"
+						app:constraint_referenced_ids="container_chapters_inline,textView_chapters_title"
 						tools:visibility="visible" />
 
 				</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -349,11 +349,20 @@
 						android:singleLine="true"
 						android:text="@string/chapters"
 						android:textAppearance="?textAppearanceTitleSmall"
-						app:layout_constraintEnd_toEndOf="parent"
+						app:layout_constraintEnd_toStartOf="@id/button_chapters_order"
 						app:layout_constraintStart_toStartOf="parent"
 						app:layout_constraintTop_toBottomOf="@id/recyclerView_related" />
 
-
+					<Button
+						android:id="@+id/button_chapters_order"
+						style="@style/Widget.Usagi.Button.More"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:layout_marginEnd="8dp"
+						android:text="@string/order_oldest"
+						android:visibility="gone"
+						app:layout_constraintBaseline_toBaselineOf="@id/textView_chapters_title"
+						app:layout_constraintEnd_toEndOf="parent" />
 
 					<androidx.fragment.app.FragmentContainerView
 						android:id="@+id/container_chapters_inline"
@@ -368,7 +377,7 @@
 						android:layout_width="wrap_content"
 						android:layout_height="wrap_content"
 						android:visibility="gone"
-						app:constraint_referenced_ids="container_chapters_inline,textView_chapters_title"
+						app:constraint_referenced_ids="container_chapters_inline,textView_chapters_title,button_chapters_order"
 						tools:visibility="visible" />
 
 				</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -337,6 +337,65 @@
 						app:constraint_referenced_ids="recyclerView_related,textView_related_title,button_related_more"
 						tools:visibility="visible" />
 
+					<TextView
+						android:id="@+id/textView_chapters_title"
+						android:layout_width="0dp"
+						android:layout_height="wrap_content"
+						android:layout_marginStart="@dimen/margin_small"
+						android:layout_marginTop="@dimen/margin_small"
+						android:layout_weight="1"
+						android:gravity="center_vertical|start"
+						android:padding="@dimen/grid_spacing"
+						android:singleLine="true"
+						android:text="@string/chapters"
+						android:textAppearance="?textAppearanceTitleSmall"
+						app:layout_constraintEnd_toStartOf="@id/split_button_chapters_read"
+						app:layout_constraintStart_toStartOf="parent"
+						app:layout_constraintTop_toBottomOf="@id/recyclerView_related" />
+
+					<com.google.android.material.button.MaterialSplitButton
+						android:id="@+id/split_button_chapters_read"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:layout_marginEnd="8dp"
+						app:layout_constraintBaseline_toBaselineOf="@id/textView_chapters_title"
+						app:layout_constraintEnd_toEndOf="parent">
+
+						<Button
+							android:id="@+id/button_read"
+							style="?materialSplitButtonLeadingFilledStyle"
+							android:layout_width="wrap_content"
+							android:layout_height="wrap_content"
+							android:minWidth="@dimen/read_button_min_width"
+							android:text="@string/read" />
+
+						<Button
+							android:id="@+id/button_read_menu"
+							style="?materialSplitButtonIconFilledStyle"
+							android:layout_width="wrap_content"
+							android:layout_height="wrap_content"
+							android:contentDescription="@string/show_menu"
+							app:icon="?expandCollapseIndicator"
+							app:toggleCheckedStateOnClick="false" />
+
+					</com.google.android.material.button.MaterialSplitButton>
+
+					<androidx.fragment.app.FragmentContainerView
+						android:id="@+id/container_chapters_inline"
+						android:layout_width="0dp"
+						android:layout_height="wrap_content"
+						app:layout_constraintEnd_toEndOf="parent"
+						app:layout_constraintStart_toStartOf="parent"
+						app:layout_constraintTop_toBottomOf="@id/textView_chapters_title" />
+
+					<androidx.constraintlayout.widget.Group
+						android:id="@+id/group_chapters_inline"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:visibility="gone"
+						app:constraint_referenced_ids="container_chapters_inline,textView_chapters_title,split_button_chapters_read"
+						tools:visibility="visible" />
+
 				</androidx.constraintlayout.widget.ConstraintLayout>
 
 			</FrameLayout>

--- a/app/src/main/res/layout/activity_details_classic.xml
+++ b/app/src/main/res/layout/activity_details_classic.xml
@@ -440,11 +440,22 @@
 						android:singleLine="true"
 						android:text="@string/chapters"
 						android:textAppearance="?textAppearanceTitleSmall"
-						app:layout_constraintEnd_toEndOf="parent"
+						app:layout_constraintEnd_toStartOf="@id/button_chapters_order"
 						app:layout_constraintStart_toStartOf="parent"
 						app:layout_constraintTop_toBottomOf="@id/recyclerView_related" />
 
-					<androidx.fragment.app.FragmentContainerView
+					<Button
+						android:id="@+id/button_chapters_order"
+						style="@style/Widget.Usagi.Button.More"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:layout_marginEnd="8dp"
+						android:text="@string/order_oldest"
+						android:visibility="gone"
+						app:layout_constraintBaseline_toBaselineOf="@id/textView_chapters_title"
+						app:layout_constraintEnd_toEndOf="parent" />
+
+						<androidx.fragment.app.FragmentContainerView
 						android:id="@+id/container_chapters_inline"
 						android:layout_width="0dp"
 						android:layout_height="wrap_content"
@@ -457,7 +468,7 @@
 						android:layout_width="wrap_content"
 						android:layout_height="wrap_content"
 						android:visibility="gone"
-						app:constraint_referenced_ids="container_chapters_inline,textView_chapters_title"
+						app:constraint_referenced_ids="container_chapters_inline,textView_chapters_title,button_chapters_order"
 						tools:visibility="visible" />
 
 					<com.google.android.material.progressindicator.LinearProgressIndicator

--- a/app/src/main/res/layout/activity_details_classic.xml
+++ b/app/src/main/res/layout/activity_details_classic.xml
@@ -428,6 +428,38 @@
 						app:constraint_referenced_ids="recyclerView_related,textView_related_title,button_related_more"
 						tools:visibility="visible" />
 
+					<TextView
+						android:id="@+id/textView_chapters_title"
+						android:layout_width="0dp"
+						android:layout_height="wrap_content"
+						android:layout_marginStart="@dimen/margin_small"
+						android:layout_marginTop="@dimen/margin_small"
+						android:layout_weight="1"
+						android:gravity="center_vertical|start"
+						android:padding="@dimen/grid_spacing"
+						android:singleLine="true"
+						android:text="@string/chapters"
+						android:textAppearance="?textAppearanceTitleSmall"
+						app:layout_constraintEnd_toEndOf="parent"
+						app:layout_constraintStart_toStartOf="parent"
+						app:layout_constraintTop_toBottomOf="@id/recyclerView_related" />
+
+					<androidx.fragment.app.FragmentContainerView
+						android:id="@+id/container_chapters_inline"
+						android:layout_width="0dp"
+						android:layout_height="wrap_content"
+						app:layout_constraintEnd_toEndOf="parent"
+						app:layout_constraintStart_toStartOf="parent"
+						app:layout_constraintTop_toBottomOf="@id/textView_chapters_title" />
+
+					<androidx.constraintlayout.widget.Group
+						android:id="@+id/group_chapters_inline"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:visibility="gone"
+						app:constraint_referenced_ids="container_chapters_inline,textView_chapters_title"
+						tools:visibility="visible" />
+
 					<com.google.android.material.progressindicator.LinearProgressIndicator
 						android:id="@+id/progressBar"
 						android:layout_width="0dp"

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -897,6 +897,8 @@
     <string name="details_backdrop_blur">Độ mờ (Blur) ảnh nền</string>
     <string name="details_appearance">Giao diện màn hình chi tiết</string>
     <string name="details_appearance_summary">Phong cách, ảnh nền và hiệu ứng mờ</string>
+    <string name="details_chapters_inline">Danh sách chương trong màn hình chi tiết</string>
+    <string name="details_chapters_inline_summary">Hiển thị danh sách chương ngay trong màn hình chi tiết thay vì cửa sổ kéo lên ở dưới</string>
     <string name="preview">Xem trước</string>
     <string name="cover_only">Chỉ bìa</string>
     <string name="confirm_delete_plugin">Bạn có muốn xoá tiện ích %1$s không?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -935,6 +935,8 @@
 	<string name="details_backdrop_blur">Backdrop blur intensity</string>
 	<string name="details_appearance">Details screen appearance</string>
 	<string name="details_appearance_summary">Screen style, backdrop image and blur effect</string>
+	<string name="details_chapters_inline">Chapters in details screen</string>
+	<string name="details_chapters_inline_summary">Show the chapter list in the manga details screen instead of the bottom sheet</string>
 	<string name="preview">Preview</string>
 	<string name="reader_appearance">Reader interface</string>
 	<string name="reader_appearance_summary">Customize layout, gestures and opacity in reader interface</string>

--- a/app/src/main/res/xml/pref_details_appearance.xml
+++ b/app/src/main/res/xml/pref_details_appearance.xml
@@ -28,6 +28,12 @@
             android:title="@string/details_ui"
             app:useSimpleSummaryProvider="true" />
 
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="details_chapters_inline"
+            android:summary="@string/details_chapters_inline_summary"
+            android:title="@string/details_chapters_inline" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/details_backdrop">


### PR DESCRIPTION
## What

Adds a new setting under **Details screen appearance** — "Chapters in details screen" — that replaces the chapters bottom sheet with an inline chapter list rendered directly below **Related manga** in the manga details screen.

## Why

The bottom-sheet chapter list is convenient but hides the chapters behind a pull-up gesture. With the new option the chapter list is always visible when scrolling the details page, matching the "everything on one screen" pattern used by other readers.

## How

- **Setting**: `details_chapters_inline` (Boolean, default `false`) in `pref_details_appearance.xml`, exposed via `AppSettings.isChaptersInlineEnabled`.
- **Layouts (phone only)**: new "Chapters" section after `group_related` in `activity_details.xml` (with a read `MaterialSplitButton` reusing `ReadButtonDelegate`) and `activity_details_classic.xml` (no split button — classic already has its own read button). Both wrap the section in `group_chapters_inline` (GONE by default) and host the existing `ChaptersFragment` in `container_chapters_inline`.
- **Activities**: when the option is on, `DetailsActivity` / `DetailsClassicActivity` hide `container_bottom_sheet` + `navbarDim`, show the inline group, add `ChaptersFragment` programmatically (so the fragment is never created when the option is off), attach `ReadButtonDelegate` (modern), and return `null` from `BottomSheetOwner.bottomSheet` so snackbars anchor to the scroll view. Peek-height bottom padding and navbar-dim insets handling are skipped while inline.
- Tablets (w600dp-land) are intentionally unchanged — they already render chapters in the side card and have no bottom sheet, so the setting is a no-op there.

## Limitations

- Phone layouts only (see above).
- While inline, the Pages/Bookmarks tabs and the sheet toolbar toggles (reverse order, grid, downloaded-only) are not reachable from the details screen.

## Test

- `./gradlew :app:compileDebugKotlin` passes.